### PR TITLE
feat: added template support for email subject

### DIFF
--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Metrics.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Metrics.scala
@@ -869,7 +869,7 @@ object Metrics {
   }
 
   /**
-   * TDigest Get precentile column metric configuration
+   * TDigest Get percentile column metric configuration
    *
    * @param id          Metric ID
    * @param source      Source ID over which metric is being calculated

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Outputs.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Outputs.scala
@@ -112,16 +112,19 @@ object Outputs {
     val template: Option[NonEmptyString]
     val templateFile: Option[URI]
     val templateFormat: TemplateFormat
+    val subjectTemplate: Option[NonEmptyString]
   }
   
   /**
    * Base trait for targets that are sent via email.
    * Configuration for such targets must contain non-empty sequence of recipients' emails.
-   * In addition an optional message template can be provided in form of either an explicit string
+   * An optional message template can be provided in form of either an explicit string
    * or an URI to template file location.
+   * In addition, email subject can be customized by providing optional subject template.
    */
   trait EmailOutputConfig extends NotificationOutputConfig {
     val recipients: Seq[Email] Refined NonEmpty
+    val subjectTemplate: Option[NonEmptyString]
     val template: Option[NonEmptyString]
     val templateFile: Option[URI]
 
@@ -137,12 +140,13 @@ object Outputs {
    * or usernames prefixed with '@' symbols.
    * In addition an optional message template can be provided in form of either an explicit string
    * or an URI to template file location.
+   * @note Mattermost message do not have subjects, therefore, subjectTemplate is set to None
    */
   trait MattermostOutputConfig extends NotificationOutputConfig {
     val recipients: Seq[MMRecipient] Refined NonEmpty
     val template: Option[NonEmptyString]
     val templateFile: Option[URI]
-
+    val subjectTemplate: Option[NonEmptyString] = None
     val recipientsList: Seq[String] = recipients.value.map(_.value)
     val templateFormat: TemplateFormat = TemplateFormat.Markdown
   }

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Targets.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Targets.scala
@@ -143,6 +143,12 @@ object Targets {
    * @param metrics Sequence of metrics to collect errors for.
    *                Default: empty sequence (collect errors for all metrics)
    * @param dumpSize Maximum number of errors collected per each metric. Default: 100
+   * @param subjectTemplate Mustache template used to customize email subject. If omitted, default subject name is used.
+   * @param template Mustache Html template for email body.
+   * @param templateFile Location of file with Mustache Html template for email body. 
+   * @note Template for email body can be provided either explicitly in `template` argument
+   * or read from file provided in `templateFile` argument. Both of these arguments are allowed.
+   * Also, if both of these arguments are omitted, then default email body is used.
    */
   final case class SummaryEmailTargetConfig(
                                              recipients: Seq[Email] Refined NonEmpty,
@@ -150,6 +156,7 @@ object Targets {
                                              attachFailedChecks: Boolean = false,
                                              metrics: Seq[NonEmptyString] = Seq.empty,
                                              dumpSize: PositiveInt = 100,
+                                             subjectTemplate: Option[NonEmptyString],
                                              template: Option[NonEmptyString],
                                              templateFile: Option[URI]
                                            ) extends SummaryTargetConfig with EmailOutputConfig
@@ -197,11 +204,18 @@ object Targets {
    * @param id Check alert ID
    * @param recipients Non-empty sequence of recipients' emails.
    * @param checks Sequence of checks to send alerts for. Default: empty sequence (send alerts for all checks)
+   * @param subjectTemplate Mustache template used to customize email subject. If omitted, default subject name is used.
+   * @param template Mustache Html template for email body.
+   * @param templateFile Location of file with Mustache Html template for email body. 
+   * @note Template for email body can be provided either explicitly in `template` argument
+   * or read from file provided in `templateFile` argument. Both of these arguments are allowed.
+   * Also, if both of these arguments are omitted, then default email body is used.
    */
   final case class CheckAlertEmailTargetConfig(
                                                 id: ID,
                                                 recipients: Seq[Email] Refined NonEmpty,
                                                 checks: Seq[NonEmptyString] = Seq.empty,
+                                                subjectTemplate: Option[NonEmptyString],
                                                 template: Option[NonEmptyString],
                                                 templateFile: Option[URI]
                                               ) extends CheckAlertTargetConfig with EmailOutputConfig

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/notification/CheckAlertNotificationBuilder.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/notification/CheckAlertNotificationBuilder.scala
@@ -40,7 +40,7 @@ trait CheckAlertNotificationBuilder[T <: CheckAlertTargetConfig with Notificatio
        |**Some of the watched checks have failed. Please, review attached files.**
        |""".stripMargin
 
-  protected val subjectTemplate: String = s"Data Quality Failed Check Alert for job '{{ jobId }}' at {{ referenceDate }}"
+  protected val defaultSubjectTemplate: String = s"Data Quality Failed Check Alert for job '{{ jobId }}' at {{ referenceDate }}"
 
   /**
    * Build target output given the target configuration
@@ -70,7 +70,7 @@ trait CheckAlertNotificationBuilder[T <: CheckAlertTargetConfig with Notificatio
 
       NotificationMessage(
         body,
-        getSubject(results.summaryMetrics),
+        getSubject(target.subjectTemplate.map(_.value), results.summaryMetrics),
         target.recipientsList,
         checksAttachments
       )

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/notification/NotificationBuilder.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/notification/NotificationBuilder.scala
@@ -16,7 +16,7 @@ trait NotificationBuilder extends BuildHelpers {
 
   protected val defaultHtmlTemplate: String
   protected val defaultMarkdownTemplate: String
-  protected val subjectTemplate: String
+  protected val defaultSubjectTemplate: String
 
   protected def buildBody(summaryMetrics: ResultSummaryMetrics,
                           format: TemplateFormat,
@@ -57,7 +57,8 @@ trait NotificationBuilder extends BuildHelpers {
       ))
     }
 
-  protected def getSubject(summaryMetrics: ResultSummaryMetrics)
+  protected def getSubject(subjectTemplate: Option[String],
+                           summaryMetrics: ResultSummaryMetrics)
                           (implicit settings: AppSettings): String =
-    renderTemplate(subjectTemplate, summaryMetrics.getFieldsMap)
+    renderTemplate(subjectTemplate.getOrElse(defaultSubjectTemplate), summaryMetrics.getFieldsMap)
 }

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/notification/SummaryNotificationBuilder.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/notification/SummaryNotificationBuilder.scala
@@ -57,7 +57,7 @@ trait SummaryNotificationBuilder[T <: SummaryTargetConfig with NotificationOutpu
        |**Failed checks**: `{{ listFailedChecks }}`
        |""".stripMargin
 
-  protected val subjectTemplate: String = s"Data Quality Summary Report for job '{{ jobId }}' at {{ referenceDate }}"
+  protected val defaultSubjectTemplate: String = s"Data Quality Summary Report for job '{{ jobId }}' at {{ referenceDate }}"
 
   /**
    * Build target output given the target configuration
@@ -87,11 +87,11 @@ trait SummaryNotificationBuilder[T <: SummaryTargetConfig with NotificationOutpu
 
     NotificationMessage(
       body,
-      getSubject(results.summaryMetrics),
+      getSubject(target.subjectTemplate.map(_.value), results.summaryMetrics),
       target.recipientsList,
       metricsAttachment ++ checksAttachments
     )
   }.toResult(
-    preMsg = s"Unable to prepare summary message with due to following error:"
+    preMsg = s"Unable to prepare summary message due to following error:"
   )
 }


### PR DESCRIPTION
Email subject can be customised. If template is not provided then the default one is used.

Tested manually.

Closes #6 