### PR TITLE
feat: adding streaming sources and stream readers

### DIFF
--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/appsettings/AppSettings.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/appsettings/AppSettings.scala
@@ -4,7 +4,7 @@ import org.apache.log4j.Level
 import org.apache.spark.SparkConf
 import ru.raiffeisen.checkita.config.IO.readAppConfig
 import ru.raiffeisen.checkita.config.Parsers._
-import ru.raiffeisen.checkita.config.appconf.{AppConfig, EmailConfig, MattermostConfig, StorageConfig}
+import ru.raiffeisen.checkita.config.appconf.{AppConfig, EmailConfig, MattermostConfig, StorageConfig, StreamConfig}
 import ru.raiffeisen.checkita.utils.Common.{paramsSeqToMap, prepareConfig}
 import ru.raiffeisen.checkita.utils.ResultUtils._
 import ru.raiffeisen.checkita.utils.EnrichedDT
@@ -27,6 +27,7 @@ import scala.util.Try
  * @param storageConfig Configuration of connection to Data Quality Storage
  * @param emailConfig Configuration of connection to SMTP server
  * @param mattermostConfig Configuration of connection to Mattermost API
+ * @param streamConfig Streaming settings (used in streaming applications only)
  * @param sparkConf Spark configuration parameters
  * @param isLocal Boolean flag indicating whether spark application must be run locally.
  * @param isShared Boolean flag indicating whether spark application running within shared spark context.
@@ -47,6 +48,7 @@ final case class AppSettings(
                               storageConfig: Option[StorageConfig],
                               emailConfig: Option[EmailConfig],
                               mattermostConfig: Option[MattermostConfig],
+                              streamConfig: StreamConfig,
                               sparkConf: SparkConf,
                               isLocal: Boolean,
                               isShared: Boolean,
@@ -124,6 +126,7 @@ object AppSettings {
         appConfig.storage,
         appConfig.email,
         appConfig.mattermost,
+        appConfig.streaming,
         conf,
         isLocal,
         isShared,
@@ -190,6 +193,7 @@ object AppSettings {
       defaultAppConf.storage,
       defaultAppConf.email,
       defaultAppConf.mattermost,
+      defaultAppConf.streaming,
       new SparkConf(),
       isLocal = false,
       isShared = false,

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/RefinedTypes.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/RefinedTypes.scala
@@ -57,4 +57,7 @@ object RefinedTypes {
    * @param formatter - datetime formatter for pattern
    */
   case class DateFormat(pattern: String, @transient formatter: DateTimeFormatter)
+  object DateFormat {
+    def fromString(s: String): DateFormat = DateFormat(s, DateTimeFormatter.ofPattern(s))
+  }
 }

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/AppConfig.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/AppConfig.scala
@@ -18,6 +18,7 @@ final case class AppConfig(
                             storage: Option[StorageConfig],
                             email: Option[EmailConfig],
                             mattermost: Option[MattermostConfig],
+                            streaming: StreamConfig = StreamConfig(),
                             dateTimeOptions: DateTimeConfig = DateTimeConfig(),
                             enablers: Enablers = Enablers(),
                             defaultSparkOptions: Seq[SparkParam] = Seq.empty,

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/DateTimeConfig.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/DateTimeConfig.scala
@@ -13,12 +13,6 @@ import ru.raiffeisen.checkita.config.RefinedTypes.DateFormat
  */
 case class DateTimeConfig(
                            timeZone: ZoneId = ZoneId.of("UTC"),
-                           referenceDateFormat: DateFormat = DateFormat(
-                             pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS",
-                             formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")
-                           ),
-                           executionDateFormat: DateFormat = DateFormat(
-                             pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS",
-                             formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")
-                           )
+                           referenceDateFormat: DateFormat = DateFormat.fromString("yyyy-MM-dd'T'HH:mm:ss.SSS"),
+                           executionDateFormat: DateFormat = DateFormat.fromString("yyyy-MM-dd'T'HH:mm:ss.SSS")
                          )

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/StreamConfig.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/StreamConfig.scala
@@ -1,0 +1,20 @@
+package ru.raiffeisen.checkita.config.appconf
+
+import scala.concurrent.duration.Duration
+import java.util.UUID
+
+/**
+ * Application-level configuration describing streaming settings
+ * @param trigger Trigger interval: defines time interval for which micro-batches are collected.
+ * @param window Window interval: defines tabbing window size used to accumulate metrics.
+ * @param watermark Watermark level: defines time interval after which late records are no longer processed.
+ */
+case class StreamConfig(
+                         trigger: Duration = Duration("10s"),
+                         window: Duration = Duration("10m"),
+                         watermark: Duration = Duration("5m")
+                       ) {
+  // random column names are generated to be used for windowing:
+  lazy val windowTsCol: String = UUID.randomUUID.toString.replace("-", "")
+  lazy val eventTsCol: String = UUID.randomUUID.toString.replace("-", "")
+}

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Files.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Files.scala
@@ -1,7 +1,7 @@
 package ru.raiffeisen.checkita.config.jobconf
 
 import eu.timepit.refined.types.string.NonEmptyString
-import ru.raiffeisen.checkita.config.RefinedTypes.URI
+import ru.raiffeisen.checkita.config.RefinedTypes.{ID, URI}
 
 /**
  * @note General note on working with files in Checkita Framework:
@@ -19,9 +19,11 @@ object Files {
   /**
    * Base trait for all types of configurations that refer to a file.
    * All such configurations must contain a path to a file.
+   * In addition, optional schemaId can be provided to point to a schema used for data reading.
    */
   trait FileConfig {
     val path: URI
+    val schema: Option[ID]
   }
 
   /**
@@ -37,9 +39,13 @@ object Files {
   /**
    * Base trait for Avro files. Configuration for avro files may contain reference to avro schema ID.
    */
-  trait AvroFileConfig extends FileConfig {
-    val schema: Option[NonEmptyString]
-  }
+  trait AvroFileConfig extends FileConfig
+
+  /**
+   * Base trait for fixed-width text files.
+   * For such files configuration must contain reference explicit fixed (full or short) schema ID
+   */
+  trait FixedFileConfig extends FileConfig
 
   /**
    * Base trait for delimited text files such as CSV or TSV.
@@ -55,14 +61,6 @@ object Files {
     val quote: NonEmptyString
     val escape: NonEmptyString
     val header: Boolean
-    val schema: Option[NonEmptyString]
   }
 
-  /**
-   * Base trait for fixed-width text files.
-   * For such files configuration must contain reference explicit fixed (full or short) schema ID
-   */
-  trait FixedFileConfig extends FileConfig {
-    val schema: NonEmptyString
-  }
 }

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/JobConfig.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/JobConfig.scala
@@ -1,12 +1,12 @@
 package ru.raiffeisen.checkita.config.jobconf
 
-import ru.raiffeisen.checkita.config.RefinedTypes.{ID, SparkParam}
+import ru.raiffeisen.checkita.config.RefinedTypes.ID
 import ru.raiffeisen.checkita.config.jobconf.Checks.ChecksConfig
 import ru.raiffeisen.checkita.config.jobconf.Connections.ConnectionsConfig
 import ru.raiffeisen.checkita.config.jobconf.LoadChecks.LoadChecksConfig
 import ru.raiffeisen.checkita.config.jobconf.Metrics.MetricsConfig
 import ru.raiffeisen.checkita.config.jobconf.Schemas.SchemaConfig
-import ru.raiffeisen.checkita.config.jobconf.Sources.{SourcesConfig, VirtualSourceConfig}
+import ru.raiffeisen.checkita.config.jobconf.Sources.{SourcesConfig, StreamSourcesConfig, VirtualSourceConfig}
 import ru.raiffeisen.checkita.config.jobconf.Targets.TargetsConfig
 
 /**
@@ -14,7 +14,8 @@ import ru.raiffeisen.checkita.config.jobconf.Targets.TargetsConfig
  * @param jobId Job ID
  * @param connections Connections to external data systems (RDBMS, Message Brokers, etc.)
  * @param schemas Various schema definitions
- * @param sources Data sources processed within current job.
+ * @param sources Data sources processed within current job (only applicable to batch jobs).
+ * @param streams Stream sources processed within current job (only applicable to streaming jobs).
  * @param virtualSources Virtual sources to be created from basic sources
  * @param loadChecks Load checks to be performed on data sources before reading data itself
  * @param metrics Metrics to be calculated for data sources
@@ -26,6 +27,7 @@ final case class JobConfig(
                             connections: Option[ConnectionsConfig],
                             schemas: Seq[SchemaConfig] = Seq.empty,
                             sources: Option[SourcesConfig],
+                            streams: Option[StreamSourcesConfig],
                             virtualSources: Seq[VirtualSourceConfig] = Seq.empty,
                             loadChecks: Option[LoadChecksConfig],
                             metrics: Option[MetricsConfig],

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Outputs.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Outputs.scala
@@ -5,7 +5,7 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.types.string.NonEmptyString
 import ru.raiffeisen.checkita.config.Enums.TemplateFormat
-import ru.raiffeisen.checkita.config.RefinedTypes.{Email, MMRecipient, SparkParam, URI}
+import ru.raiffeisen.checkita.config.RefinedTypes.{Email, ID, MMRecipient, SparkParam, URI}
 import ru.raiffeisen.checkita.config.jobconf.Files._
 
 
@@ -45,7 +45,7 @@ object Outputs {
                                               header: Boolean = false
                                             ) extends FileOutputConfig with DelimitedFileConfig {
     // Schema is not required as input parameter as it is enforced on write.
-    val schema: Option[NonEmptyString] = None
+    val schema: Option[ID] = None
   }
 
   /**
@@ -56,7 +56,7 @@ object Outputs {
   final case class AvroFileOutputConfig(
                                          path: URI
                                        ) extends FileOutputConfig with AvroFileConfig {
-    val schema: Option[NonEmptyString] = None
+    val schema: Option[ID] = None
   }
 
   /**
@@ -66,7 +66,9 @@ object Outputs {
    */
   final case class OrcFileOutputConfig(
                                         path: URI
-                                      ) extends FileOutputConfig with OrcFileConfig
+                                      ) extends FileOutputConfig with OrcFileConfig {
+    val schema: Option[ID] = None
+  }
 
   /**
    * Parquet file output configuration
@@ -75,7 +77,9 @@ object Outputs {
    */
   final case class ParquetFileOutputConfig(
                                             path: URI
-                                          ) extends FileOutputConfig with ParquetFileConfig
+                                          ) extends FileOutputConfig with ParquetFileConfig {
+    val schema: Option[ID] = None
+  }
 
 
   /**

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/connections/DQConnection.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/connections/DQConnection.scala
@@ -3,6 +3,7 @@ package ru.raiffeisen.checkita.connections
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import ru.raiffeisen.checkita.appsettings.AppSettings
 import ru.raiffeisen.checkita.config.jobconf.Sources.SourceConfig
+import ru.raiffeisen.checkita.readers.SchemaReaders.SourceSchema
 import ru.raiffeisen.checkita.utils.ResultUtils.Result
 
 /**
@@ -24,10 +25,15 @@ abstract class DQConnection {
 
   /**
    * Loads external data into dataframe given a source configuration
+   *
    * @param sourceConfig Source configuration
-   * @param settings Implicit application settings object
-   * @param spark Implicit spark session object
+   * @param settings     Implicit application settings object
+   * @param spark        Implicit spark session object
+   * @param schemas      Implicit Map of all explicitly defined schemas (schemaId -> SourceSchema)
    * @return Spark DataFrame
    */
-  def loadDataframe(sourceConfig: SourceType)(implicit settings: AppSettings, spark: SparkSession): DataFrame
+  def loadDataFrame(sourceConfig: SourceType)
+                   (implicit settings: AppSettings,
+                    spark: SparkSession,
+                    schemas: Map[String, SourceSchema]): DataFrame
 }

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/connections/DQStreamingConnection.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/connections/DQStreamingConnection.scala
@@ -1,0 +1,25 @@
+package ru.raiffeisen.checkita.connections
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import ru.raiffeisen.checkita.appsettings.AppSettings
+import ru.raiffeisen.checkita.readers.SchemaReaders.SourceSchema
+
+/**
+ * Trait to be mix in connections that can read streams.
+ */
+trait DQStreamingConnection { this: DQConnection =>
+
+  /**
+   * Loads stream into a dataframe given the stream configuration
+   *
+   * @param sourceConfig Stream configuration
+   * @param settings     Implicit application settings object
+   * @param spark        Implicit spark session object
+   * @param schemas      Implicit Map of all explicitly defined schemas (schemaId -> SourceSchema)
+   * @return Spark Streaming DataFrame
+   */
+  def loadDataStream(sourceConfig: SourceType)
+                    (implicit settings: AppSettings,
+                     spark: SparkSession,
+                     schemas: Map[String, SourceSchema]): DataFrame
+}

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/connections/jdbc/JdbcConnection.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/connections/jdbc/JdbcConnection.scala
@@ -5,6 +5,7 @@ import ru.raiffeisen.checkita.appsettings.AppSettings
 import ru.raiffeisen.checkita.config.jobconf.Connections.JdbcConnectionConfig
 import ru.raiffeisen.checkita.config.jobconf.Sources.TableSourceConfig
 import ru.raiffeisen.checkita.connections.DQConnection
+import ru.raiffeisen.checkita.readers.SchemaReaders.SourceSchema
 import ru.raiffeisen.checkita.utils.Common.paramsSeqToMap
 import ru.raiffeisen.checkita.utils.ResultUtils._
 
@@ -51,14 +52,17 @@ abstract class JdbcConnection[T <: JdbcConnectionConfig] extends DQConnection {
 
   /**
    * Loads external data into dataframe given a source configuration
+   *
    * @param sourceConfig Source configuration
-   * @param settings Implicit application settings object
-   * @param spark Implicit spark session object
+   * @param settings     Implicit application settings object
+   * @param spark        Implicit spark session object
+   * @param schemas      Implicit Map of all explicitly defined schemas (schemaId -> SourceSchema)
    * @return Spark DataFrame
    */
-  def loadDataframe(sourceConfig: SourceType)
+  def loadDataFrame(sourceConfig: SourceType)
                    (implicit settings: AppSettings,
-                    spark: SparkSession): DataFrame = {
+                    spark: SparkSession,
+                    schemas: Map[String, SourceSchema]): DataFrame = {
     
     val props = getProperties
     paramsSeqToMap(sparkParams).foreach{ case (k, v) => props.put(k, v) }

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/connections/kafka/KafkaConnection.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/connections/kafka/KafkaConnection.scala
@@ -4,22 +4,24 @@ import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.functions.{col, from_json, udf}
-import org.apache.spark.sql.types.StringType
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{LongType, StringType, TimestampType}
+import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 import org.json.XML
 import ru.raiffeisen.checkita.appsettings.AppSettings
-import ru.raiffeisen.checkita.config.Enums.KafkaTopicFormat
+import ru.raiffeisen.checkita.config.Enums.{CustomTime, EventTime, KafkaTopicFormat, ProcessingTime}
 import ru.raiffeisen.checkita.config.jobconf.Connections.KafkaConnectionConfig
 import ru.raiffeisen.checkita.config.jobconf.Sources.KafkaSourceConfig
-import ru.raiffeisen.checkita.connections.DQConnection
+import ru.raiffeisen.checkita.connections.{DQConnection, DQStreamingConnection}
+import ru.raiffeisen.checkita.readers.SchemaReaders.SourceSchema
 import ru.raiffeisen.checkita.utils.Common.paramsSeqToMap
 import ru.raiffeisen.checkita.utils.ResultUtils._
+import ru.raiffeisen.checkita.utils.SparkUtils.DurationOps
 
 import java.util.Properties
 import scala.util.Try
 
-case class KafkaConnection(config: KafkaConnectionConfig) extends DQConnection {
+case class KafkaConnection(config: KafkaConnectionConfig) extends DQConnection with DQStreamingConnection {
   type SourceType = KafkaSourceConfig
   val id: String = config.id.value
   protected val sparkParams: Seq[String] = config.parameters.map(_.value)
@@ -31,11 +33,12 @@ case class KafkaConnection(config: KafkaConnectionConfig) extends DQConnection {
   
   /**
    * Gets proper subscribe option for given source configuration.
-   * @param conf Kafka source configuration
+   * @param topics List of Kafka topics (can be empty)
+   * @param topicPattern Topic pattern (optional)
    * @return Topic(s) subscribe option
    */
-  private def getSubscribeOption(conf: SourceType): (String, String) =
-    (conf.topics.map(_.value), conf.topicPattern.map(_.value)) match {
+  private def getSubscribeOption(topics: Seq[String], topicPattern: Option[String]): (String, String) =
+    (topics, topicPattern) match {
       case (ts@_ :: _, None) => if (ts.forall(_.contains("@"))) {
         "assign" -> ts.map(_.split("@")).collect {
           case Array(topic, partitions) => "\"" + topic + "\":" + partitions
@@ -52,7 +55,41 @@ case class KafkaConnection(config: KafkaConnectionConfig) extends DQConnection {
           "topics must be defined either explicitly as a sequence of topic names or as a topic pattern."
       )
     }
-  
+
+  /**
+   * Decodes kafka message key and value columns given their format.
+   * @param colName Name of the column to decode (either 'key' or 'value')
+   * @param format Column format to parse
+   * @param schemaId Schema ID used to parse column of JSON or XML format
+   * @param schemas Map of all explicitly defined schemas (schemaId -> SourceSchema)
+   * @return Decoded column
+   */
+  private def decodeColumn(colName: String, format: KafkaTopicFormat, schemaId: Option[String])
+                          (implicit schemas: Map[String, SourceSchema]): Column = {
+
+    val schemaGetter = (formatStr: String) => {
+      val keySchemaId = schemaId.getOrElse(throw new IllegalArgumentException(
+        s"Schema must be provided in order to parse kafka message '$colName' column of $formatStr format"
+      ))
+      schemas.getOrElse(keySchemaId,
+        throw new NoSuchElementException(s"Schema with id = '$keySchemaId' not found.")
+      )
+    }
+
+    format match {
+      case KafkaTopicFormat.String => col(colName).cast(StringType).as(colName)
+      case KafkaTopicFormat.Json =>
+        val keySchema = schemaGetter("JSON")
+        from_json(col(colName).cast(StringType), keySchema.schema).alias(colName)
+      case KafkaTopicFormat.Xml =>
+        val keySchema = schemaGetter("XML")
+        from_json(xmlToJson(col(colName).cast(StringType)), keySchema.schema).alias(colName)
+      case other => throw new IllegalArgumentException(
+        s"Wrong kafka topic message format for column '$colName': ${other.toString}"
+      ) // we do not support avro for now.
+    }
+  }
+
   /**
    * Checks connection.
    *
@@ -68,36 +105,73 @@ case class KafkaConnection(config: KafkaConnectionConfig) extends DQConnection {
 
   /**
    * Loads external data into dataframe given a source configuration
-   * @param settings Implicit application settings object
-   * @param spark Implicit spark session object
+   *
    * @param sourceConfig Source configuration
+   * @param settings     Implicit application settings object
+   * @param spark        Implicit spark session object
+   * @param schemas      Implicit Map of all explicitly defined schemas (schemaId -> SourceSchema)
    * @return Spark DataFrame
    */
-  def loadDataframe(sourceConfig: SourceType)
+  def loadDataFrame(sourceConfig: SourceType)
                    (implicit settings: AppSettings,
-                    spark: SparkSession): DataFrame = {
-    import spark.implicits._
+                    spark: SparkSession,
+                    schemas: Map[String, SourceSchema]): DataFrame = {
     
     val allOptions = kafkaParams ++ 
       paramsSeqToMap(sourceConfig.options.map(_.value)) + 
-      getSubscribeOption(sourceConfig) +
-      ("startingOffsets" -> sourceConfig.startingOffsets.value) +
-      ("endingOffsets" -> sourceConfig.endingOffsets.value)
+      getSubscribeOption(sourceConfig.topics.map(_.value), sourceConfig.topicPattern.map(_.value)) +
+      ("startingOffsets" -> sourceConfig.startingOffsets.map(_.value).getOrElse("earliest")) +
+      ("endingOffsets" -> sourceConfig.endingOffsets.map(_.value).getOrElse("latest"))
 
     val rawDF = spark.read.format("kafka").options(allOptions).load()
-    val decodedDF = sourceConfig.format match {
-      case KafkaTopicFormat.Json =>
-        rawDF.select(col("value").cast(StringType).alias("data"))
-      case KafkaTopicFormat.Xml =>
-        rawDF.select(xmlToJson(col("value").cast(StringType)).alias("data"))
-      case fmt => throw new IllegalArgumentException(
-        s"Wrong kafka topic format for kafka source $id: ${fmt.toString}"
-      ) // we do not support avro for now.
+
+    val keyColumn = decodeColumn("key", sourceConfig.keyFormat, sourceConfig.keySchema.map(_.value))
+    val valueColumn = decodeColumn("value", sourceConfig.valueFormat, sourceConfig.valueSchema.map(_.value))
+
+    rawDF.select(keyColumn, valueColumn)
+  }
+
+  /**
+   * Loads stream into a dataframe given the stream configuration
+   *
+   * @param sourceConfig Source configuration
+   * @param settings     Implicit application settings object
+   * @param spark        Implicit spark session object
+   * @param schemas      Implicit Map of all explicitly defined schemas (schemaId -> SourceSchema)
+   * @return Spark Streaming DataFrame
+   */
+  def loadDataStream(sourceConfig: SourceType)
+                    (implicit settings: AppSettings,
+                     spark: SparkSession,
+                     schemas: Map[String, SourceSchema]): DataFrame = {
+    val allOptions = kafkaParams ++
+      paramsSeqToMap(sourceConfig.options.map(_.value)) +
+      getSubscribeOption(sourceConfig.topics.map(_.value), sourceConfig.topicPattern.map(_.value)) +
+      ("startingOffsets" -> sourceConfig.startingOffsets.map(_.value).getOrElse("latest"))
+
+    val windowTsCol = settings.streamConfig.windowTsCol
+    val eventTsCol = settings.streamConfig.eventTsCol
+    val windowDuration = settings.streamConfig.window.toSparkInterval
+
+    val rawStream = spark.readStream.format("kafka").options(allOptions).load()
+
+    val keyColumn = decodeColumn("key", sourceConfig.keyFormat, sourceConfig.keySchema.map(_.value))
+    val valueColumn = decodeColumn("value", sourceConfig.valueFormat, sourceConfig.valueSchema.map(_.value))
+    val eventColumn = sourceConfig.windowBy match {
+      case ProcessingTime => current_timestamp().cast(LongType)
+      case EventTime => col("timestamp")
+      case CustomTime(colName) => col(colName).cast(LongType)
     }
 
-    val schema = spark.read.json(decodedDF.select("data").as[String]).schema
-    
-    decodedDF.withColumn("jsonData", from_json(col("data"), schema)).select("jsonData.*")
+    rawStream.select(keyColumn, valueColumn, col("timestamp"))
+      .withColumn(eventTsCol, eventColumn)
+      .withColumn(s"${windowTsCol}_pre", window(col(eventTsCol).cast(TimestampType), windowDuration))
+      .select(
+        col(eventTsCol),
+        col(s"${windowTsCol}_pre").getField("start").cast(LongType).as(windowTsCol),
+        col("key"),
+        col("value")
+      )
   }
 
   /**

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/context/DQContext.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/context/DQContext.scala
@@ -44,7 +44,7 @@ import scala.util.Try
  */
 class DQContext(settings: AppSettings, spark: SparkSession, fs: FileSystem) extends Logging {
 
-  implicit private val sparkSess: SparkSession = spark
+  implicit private val sparkSes: SparkSession = spark
   implicit private val fileSystem: FileSystem = fs
   implicit private val appSettings: AppSettings = settings
   

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/Source.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/Source.scala
@@ -4,7 +4,8 @@ import org.apache.spark.sql.DataFrame
 
 /**
  * Data Quality Source definition
- *
+ * @note Source can hold both static and streaming dataframes and, therefore, both batch source readers
+ *       and stream source readers return same source definition.
  * @param id        Source ID
  * @param df        Spark dataframe with source data
  * @param keyFields Key field (columns) of this source: uniquely define data row
@@ -15,4 +16,6 @@ case class Source(
                    df: DataFrame,
                    keyFields: Seq[String] = Seq.empty,
                    parents: Seq[String] = Seq.empty
-                 )
+                 ) {
+  val isStreaming: Boolean = df.isStreaming
+}

--- a/checkita-core/src/test/scala/ru/raiffeisen/checkita/readers/SourceReadersSpec.scala
+++ b/checkita-core/src/test/scala/ru/raiffeisen/checkita/readers/SourceReadersSpec.scala
@@ -87,10 +87,10 @@ class SourceReadersSpec extends AnyWordSpec with Matchers {
     
     "correctly read fixed-width text file" in {
       val fixedFullSourceConfig = FixedFileSourceConfig(
-        ID("fixedFullSource"), Refined.unsafeApply(filePath), "fixedFull"
+        ID("fixedFullSource"), Refined.unsafeApply(filePath), Some(ID("fixedFull"))
       )
       val fixedShortSourceConfig = FixedFileSourceConfig(
-        ID("fixedShortSource"), Refined.unsafeApply(filePath), "fixedShort"
+        ID("fixedShortSource"), Refined.unsafeApply(filePath), Some(ID("fixedShort"))
       )
       
       val fixedFullSource = FixedFileSourceReader.read(fixedFullSourceConfig)
@@ -110,12 +110,12 @@ class SourceReadersSpec extends AnyWordSpec with Matchers {
     }
     
     "return error when file not found" in {
-      val sourceConfig = FixedFileSourceConfig(ID("fixedFullSource"), "some_file.txt", "fixedFull")
+      val sourceConfig = FixedFileSourceConfig(ID("fixedFullSource"), "some_file.txt", Some(ID("fixedFull")))
       FixedFileSourceReader.read(sourceConfig).isLeft shouldEqual true
     }
 
     "return error when schema not found" in {
-      val sourceConfig = FixedFileSourceConfig(ID("fixedFullSource"), Refined.unsafeApply(filePath), "some_schema")
+      val sourceConfig = FixedFileSourceConfig(ID("fixedFullSource"), Refined.unsafeApply(filePath), Some(ID("some_schema")))
       FixedFileSourceReader.read(sourceConfig).isLeft shouldEqual true
     }
   }
@@ -129,7 +129,7 @@ class SourceReadersSpec extends AnyWordSpec with Matchers {
         ID("sourceHeader"), Refined.unsafeApply(fileWithHeader), header = true, schema = None
       )
       val sourceConfigHeadless = DelimitedFileSourceConfig(
-        ID("sourceHeadless"), Refined.unsafeApply(fileWithoutHeader), schema = Some("delimited")
+        ID("sourceHeadless"), Refined.unsafeApply(fileWithoutHeader), schema = Some(ID("delimited"))
       )
       
       val sourceHeader = DelimitedFileSourceReader.read(sourceConfigHeader)
@@ -155,14 +155,14 @@ class SourceReadersSpec extends AnyWordSpec with Matchers {
 
     "return error when schema not found" in {
       val sourceConfig = DelimitedFileSourceConfig(
-        ID("sourceHeadless"), Refined.unsafeApply(fileWithoutHeader), schema = Some("some_schema")
+        ID("sourceHeadless"), Refined.unsafeApply(fileWithoutHeader), schema = Some(ID("some_schema"))
       )
       DelimitedFileSourceReader.read(sourceConfig).isLeft shouldEqual true
     }
     
     "return error when both header and schema are provided in source configuration or none of them is provided" in {
       val sourceConfig1 = DelimitedFileSourceConfig(
-        ID("sourceConfig1"), Refined.unsafeApply(fileWithHeader), header = true, schema = Some("some_schema")
+        ID("sourceConfig1"), Refined.unsafeApply(fileWithHeader), header = true, schema = Some(ID("some_schema"))
       )
       val sourceConfig2 = DelimitedFileSourceConfig(
         ID("sourceConfig2"), Refined.unsafeApply(fileWithHeader), schema = None
@@ -192,7 +192,7 @@ class SourceReadersSpec extends AnyWordSpec with Matchers {
 
     "correctly read avro file with schema" in {
       val sourceConfig = AvroFileSourceConfig(
-        ID("avroSource"), Refined.unsafeApply(avroFilePath), schema = Some("avro")
+        ID("avroSource"), Refined.unsafeApply(avroFilePath), schema = Some(ID("avro"))
       )
 
       val source = AvroFileSourceReader.read(sourceConfig)
@@ -212,7 +212,7 @@ class SourceReadersSpec extends AnyWordSpec with Matchers {
 
     "return error when schema provided but not found" in {
       val sourceConfig = AvroFileSourceConfig(
-        ID("avroSource"), Refined.unsafeApply(avroFilePath), schema = Some("some_schema")
+        ID("avroSource"), Refined.unsafeApply(avroFilePath), schema = Some(ID("some_schema"))
       )
       AvroFileSourceReader.read(sourceConfig).isLeft shouldEqual true
     }
@@ -222,7 +222,7 @@ class SourceReadersSpec extends AnyWordSpec with Matchers {
     val parquetFilePath = getClass.getResource("/data/companies/inc_500_companies_2019.parquet").getPath
 
     "correctly read parquet file" in {
-      val sourceConfig = ParquetFileSourceConfig(ID("parquetSource"), Refined.unsafeApply(parquetFilePath))
+      val sourceConfig = ParquetFileSourceConfig(ID("parquetSource"), Refined.unsafeApply(parquetFilePath), None)
 
       val source = ParquetFileSourceReader.read(sourceConfig)
 
@@ -235,7 +235,7 @@ class SourceReadersSpec extends AnyWordSpec with Matchers {
     }
 
     "return error when file not found" in {
-      val sourceConfig = ParquetFileSourceConfig(ID("parquetSource"), "some_file.txt")
+      val sourceConfig = ParquetFileSourceConfig(ID("parquetSource"), "some_file.txt", None)
       ParquetFileSourceReader.read(sourceConfig).isLeft shouldEqual true
     }
   }
@@ -244,7 +244,7 @@ class SourceReadersSpec extends AnyWordSpec with Matchers {
     val orcFilePath = getClass.getResource("/data/companies/inc_500_companies_2019.orc").getPath
 
     "correctly read orc file" in {
-      val sourceConfig = OrcFileSourceConfig(ID("orcSource"), Refined.unsafeApply(orcFilePath))
+      val sourceConfig = OrcFileSourceConfig(ID("orcSource"), Refined.unsafeApply(orcFilePath), None)
 
       val source = OrcFileSourceReader.read(sourceConfig)
 
@@ -257,7 +257,7 @@ class SourceReadersSpec extends AnyWordSpec with Matchers {
     }
 
     "return error when file not found" in {
-      val sourceConfig = OrcFileSourceConfig(ID("orcSource"), "some_file.txt")
+      val sourceConfig = OrcFileSourceConfig(ID("orcSource"), "some_file.txt", None)
       OrcFileSourceReader.read(sourceConfig).isLeft shouldEqual true
     }
   }


### PR DESCRIPTION
- configuration model of sources has changed to enable reading them as a stream dataframes. Sources that are not streamable are marked accordingly.
- added trait with loadDataStream method to mix in connections that support reading data as a stream
- Modified kafka connection to implement loadDataStream method
- Modified source readers to enable readStream method for sources.
- Application configuration has extended with streaming settings.
- other minor fixes.

All the above changes are implemented in order to support creation of streamable DQ jobs that is currently under development.