### PR TITLE
fix: enhance kakfa windowing for streams and enable avro kafka message format

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,7 @@ lazy val `checkita-core` = (project in file("checkita-core")).settings(
     case x if Assembly.isConfigFile(x) => MergeStrategy.concat
     case PathList(ps@_*) if Assembly.isReadme(ps.last) || Assembly.isLicenseFile(ps.last) =>
       MergeStrategy.rename
+    case PathList("models", xs@_*) => MergeStrategy.discard // aws-java-sdk-bundle contains lots of json data
     case PathList("META-INF", xs@_*) => xs map {
       _.toLowerCase
     } match {

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/RefinedTypes.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/RefinedTypes.scala
@@ -16,7 +16,7 @@ object RefinedTypes {
   type Port = Int Refined Interval.Closed[W.`0`.T, W.`9999`.T]
   type Email = String Refined MatchesRegex[W.`"""^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$"""`.T]
   type MMRecipient = String Refined MatchesRegex[W.`"""^(@|#)[a-zA-Z][a-zA-Z0-9.\\-_]+$"""`.T]
-  type SparkParam = String Refined MatchesRegex[W.`"""^\\S+?\\=\\S+$"""`.T]
+  type SparkParam = String Refined MatchesRegex[W.`"""^\\S+?\\=[\\S\\s]+$"""`.T]
   type PositiveInt = Int Refined Positive
   type FixedShortColumn = String Refined MatchesRegex[W.`"""^[^\\n\\r\\t:]+:\\d+$"""`.T]
   type AccuracyDouble = Double Refined Interval.Closed[W.`0.0`.T, W.`1.0`.T]

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/Enablers.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/Enablers.scala
@@ -12,7 +12,7 @@ import eu.timepit.refined.auto._
  *                              (one per each target type, except checkAlerts where
  *                              one message per checkAlert will be sent)
  * @param enableCaseSensitivity Enable columns case sensitivity
- * @param errorDumpSize Maximum number of errors to be collected per single metric.
+ * @param errorDumpSize Maximum number of errors to be collected per single metric per partition.
  * @param outputRepartition Sets the number of partitions when writing outputs. By default writes single file.
  */
 final case class Enablers(

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Sources.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Sources.scala
@@ -291,6 +291,7 @@ object Sources {
     val persist: Option[StorageLevel]
     val save: Option[FileOutputConfig]
     val parents: Seq[String]
+    val windowBy: Option[StreamWindowing]
     // additional validation will be imposed on the required number
     // of parent sources depending on virtual source type.
   }
@@ -315,6 +316,7 @@ object Sources {
                                          ) extends VirtualSourceConfig {
     val parents: Seq[String] = parentSources.value
     val streamable: Boolean = false
+    val windowBy: Option[StreamWindowing] = None
   }
 
   /**
@@ -339,6 +341,7 @@ object Sources {
                                           ) extends VirtualSourceConfig {
     val parents: Seq[String] = parentSources.value
     val streamable: Boolean = false
+    val windowBy: Option[StreamWindowing] = None
   }
 
   /**
@@ -359,6 +362,7 @@ object Sources {
                                               expr: Seq[Column] Refined NonEmpty,
                                               persist: Option[StorageLevel],
                                               save: Option[FileOutputConfig],
+                                              windowBy: Option[StreamWindowing],
                                               keyFields: Seq[NonEmptyString] = Seq.empty
                                             ) extends VirtualSourceConfig {
     val parents: Seq[String] = parentSources.value
@@ -382,6 +386,7 @@ object Sources {
                                               expr: Seq[Column] Refined NonEmpty,
                                               persist: Option[StorageLevel],
                                               save: Option[FileOutputConfig],
+                                              windowBy: Option[StreamWindowing],
                                               keyFields: Seq[NonEmptyString] = Seq.empty
                                             ) extends VirtualSourceConfig {
     val parents: Seq[String] = parentSources.value
@@ -411,6 +416,7 @@ object Sources {
                                                ) extends VirtualSourceConfig {
     val parents: Seq[String] = parentSources.value
     val streamable: Boolean = false
+    val windowBy: Option[StreamWindowing] = None
   }
 
   /**

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Targets.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Targets.scala
@@ -31,7 +31,7 @@ object Targets {
    */
   sealed abstract class ErrorCollTargetConfig extends TargetConfig {
     val metrics: Seq[NonEmptyString]
-    val dumpSize: PositiveInt
+    val dumpSize: Option[PositiveInt]
   }
 
   /**
@@ -45,7 +45,7 @@ object Targets {
     val attachMetricErrors: Boolean
     val attachFailedChecks: Boolean
     val metrics: Seq[NonEmptyString]
-    val dumpSize: PositiveInt
+    val dumpSize: Option[PositiveInt]
   }
 
   /**
@@ -72,7 +72,7 @@ object Targets {
    */
   final case class ErrorCollFileTargetConfig(
                                               metrics: Seq[NonEmptyString] = Seq.empty,
-                                              dumpSize: PositiveInt = 100,
+                                              dumpSize: Option[PositiveInt],
                                               save: FileOutputConfig
                                             ) extends ErrorCollTargetConfig with SaveToFileConfig
 
@@ -108,13 +108,13 @@ object Targets {
    * @param table Hive table to write into
    * @param metrics Sequence of metrics to collect errors for.
    *                Default: empty sequence (collect errors for all metrics)
-   * @param dumpSize Maximum number of errors collected per each metric. Default: 100
+   * @param dumpSize Maximum number of errors collected per each metric.
    */
   final case class ErrorCollHiveTargetConfig(
                                               schema: NonEmptyString,
                                               table: NonEmptyString,
                                               metrics: Seq[NonEmptyString] = Seq.empty,
-                                              dumpSize: PositiveInt = 100
+                                              dumpSize: Option[PositiveInt]
                                             ) extends ErrorCollTargetConfig with HiveOutputConfig
 
   /**
@@ -131,7 +131,7 @@ object Targets {
                                                topic: NonEmptyString,
                                                options: Seq[SparkParam] = Seq.empty,
                                                metrics: Seq[NonEmptyString] = Seq.empty,
-                                               dumpSize: PositiveInt = 100
+                                               dumpSize: Option[PositiveInt]
                                              ) extends ErrorCollTargetConfig with KafkaOutputConfig
 
   /**
@@ -155,7 +155,7 @@ object Targets {
                                              attachMetricErrors: Boolean = false,
                                              attachFailedChecks: Boolean = false,
                                              metrics: Seq[NonEmptyString] = Seq.empty,
-                                             dumpSize: PositiveInt = 100,
+                                             dumpSize: Option[PositiveInt],
                                              subjectTemplate: Option[NonEmptyString],
                                              template: Option[NonEmptyString],
                                              templateFile: Option[URI]
@@ -176,7 +176,7 @@ object Targets {
                                                   attachMetricErrors: Boolean = false,
                                                   attachFailedChecks: Boolean = false,
                                                   metrics: Seq[NonEmptyString] = Seq.empty,
-                                                  dumpSize: PositiveInt = 100,
+                                                  dumpSize: Option[PositiveInt],
                                                   template: Option[NonEmptyString],
                                                   templateFile: Option[URI]
                                                 ) extends SummaryTargetConfig with MattermostOutputConfig
@@ -196,7 +196,7 @@ object Targets {
     val attachMetricErrors: Boolean = false
     val attachFailedChecks: Boolean = false
     val metrics: Seq[NonEmptyString] = Seq.empty
-    val dumpSize: PositiveInt = 1
+    val dumpSize: Option[PositiveInt] = None
   }
                                      
   /**

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/dataframe/ErrorDataFrameBuilder.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/dataframe/ErrorDataFrameBuilder.scala
@@ -25,7 +25,11 @@ trait ErrorDataFrameBuilder[T <: ErrorCollTargetConfig] extends TargetBuilder[T,
   override def build(target: T, results: ResultSet)
                     (implicit settings: AppSettings, spark: SparkSession): Result[DataFrame] = Try {
     spark.createDataFrame(
-      filterErrors(results.metricErrors, target.metrics.map(_.value), target.dumpSize.value).map(_.toRow).asJava,
+      filterErrors(
+        results.metricErrors,
+        target.metrics.map(_.value),
+        target.dumpSize.map(_.value).getOrElse(settings.errorDumpSize)
+      ).map(_.toRow).asJava,
       schema = ResultsSerializationOps.unifiedSchema
     )
   }.toResult(

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/json/ErrorJsonBuilder.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/json/ErrorJsonBuilder.scala
@@ -23,7 +23,11 @@ trait ErrorJsonBuilder[T <: ErrorCollTargetConfig] extends TargetBuilder[T, Seq[
    */
   override def build(target: T, results: ResultSet)
                     (implicit settings: AppSettings, spark: SparkSession): Result[Seq[String]] = Try(
-    filterErrors(results.metricErrors, target.metrics.map(_.value), target.dumpSize.value).map(_.toJson)
+    filterErrors(
+      results.metricErrors,
+      target.metrics.map(_.value),
+      target.dumpSize.map(_.value).getOrElse(settings.errorDumpSize)
+    ).map(_.toJson)
   ).toResult(
     preMsg = s"Unable to prepare json data with result targets due to following error:"
   )

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/notification/SummaryNotificationBuilder.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/notification/SummaryNotificationBuilder.scala
@@ -76,7 +76,9 @@ trait SummaryNotificationBuilder[T <: SummaryTargetConfig with NotificationOutpu
 
     val metricsAttachment =
       if (target.attachMetricErrors) buildErrorsAttachment(
-        results.metricErrors, target.metrics.map(_.value), target.dumpSize.value
+        results.metricErrors,
+        target.metrics.map(_.value),
+        target.dumpSize.map(_.value).getOrElse(settings.errorDumpSize)
       ).toSeq else Seq.empty
 
     val checksAttachments =

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/utils/SparkUtils.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/utils/SparkUtils.scala
@@ -146,7 +146,7 @@ object SparkUtils {
       val eventColumn = windowBy match {
         case ProcessingTime => current_timestamp().cast(LongType)
         case EventTime => col("timestamp").cast(LongType)
-        case CustomTime(colName) => col(colName).cast(LongType)
+        case CustomTime(column) => column.cast(LongType)
       }
 
       val dfColumns = df.columns.map(c => col(c)).toSeq ++ Seq(

--- a/checkita-core/src/test/scala/ru/raiffeisen/checkita/readers/VirtualSourceReader.scala
+++ b/checkita-core/src/test/scala/ru/raiffeisen/checkita/readers/VirtualSourceReader.scala
@@ -133,6 +133,7 @@ class VirtualSourceReader extends AnyWordSpec with Matchers {
         Refined.unsafeApply(Seq(expr("key is not null"))),
         None,
         None,
+        None,
         Seq("batchId", "dttm")
       )
 
@@ -160,6 +161,7 @@ class VirtualSourceReader extends AnyWordSpec with Matchers {
         Refined.unsafeApply(Seq(expr("key is not null"))),
         None,
         None,
+        None,
         Seq("batchId", "dttm")
       )
 
@@ -179,6 +181,7 @@ class VirtualSourceReader extends AnyWordSpec with Matchers {
         ID("selectVS"),
         Refined.unsafeApply(Seq("table_source_1")),
         Refined.unsafeApply(Seq(expr("count(id) as id_cnt"), expr("count(name) as name_cnt"))),
+        None,
         None,
         None
       )
@@ -206,6 +209,7 @@ class VirtualSourceReader extends AnyWordSpec with Matchers {
         ID("selectVS"),
         Refined.unsafeApply(Seq("table_source_1", "table_source_2")),
         Refined.unsafeApply(Seq(expr("count(id) as id_cnt"), expr("count(name) as name_cnt"))),
+        None,
         None,
         None
       )

--- a/docs/en/03-job-configuration/03-Sources.md
+++ b/docs/en/03-job-configuration/03-Sources.md
@@ -172,7 +172,7 @@ parameters:
   Key fields are primarily used in error collection reports. For more details on error collection, see
   [Metric Error Collection](../02-general-concepts/04-ErrorCollection.md) chapter.
 
-Currently, `string`, `xml` and `json` formats are supported to decode message key and value.
+Currently, `string`, `xml`, `json` and `avro` formats are supported to decode message key and value.
 
 > *TIP*: In order to define JSON strings, they must be enclosed in triple quotes:
 > `"""{"name1": {"name2": "value2", "name3": "value3""}}"""`.

--- a/docs/en/03-job-configuration/04-Streams.md
+++ b/docs/en/03-job-configuration/04-Streams.md
@@ -25,7 +25,8 @@ The only additional parameter that is required to be defined for all streaming s
     * `eventTime` - Mostly applicable to kafka sources. Uses column with name `timestamp` to retrieve time value from.
       This column must be of *Timestamp* type.
     * `custom(columnName)` - Uses arbitrary user-defined column to retrieve time value from. Specified column
-      must be of *Timestamp* type. For example: `custom(value.createdAt)` - the time value for a record will be retrieved
+      must be of *Timestamp* type. In addition, an SQL expression is are supported. An expression should also evaluate 
+      to value of Timestamp type. For example: `custom(value.createdAt)` - the time value for a record will be retrieved
       from message value's field with name `createdAt`.
 
 

--- a/docs/en/03-job-configuration/06-VirtualStreams.md
+++ b/docs/en/03-job-configuration/06-VirtualStreams.md
@@ -7,7 +7,9 @@ Structured Streaming API. More details on running data quality checks over strea
 [Data Quality Checks over Streaming Sources](../02-general-concepts/05-StreamingMode.md) chapter.
 
 The configuration of virtual streaming sources is the same as for the static ones. 
-See chapter [Virtual Sources Configuration](05-VirtualSources.md) for more details.
+See chapter [Virtual Sources Configuration](05-VirtualSources.md) for more details. In addition, column used as source 
+of timestamp for windowing can be redefined and derived from the resultant virtual stream scheme. 
+See [Streaming Sources Configurations](04-Streams.md) for more details on how to define column used as source of timestamp.
 
 It is important to note that not all supported virtual sources types can be built from streaming sources. 
 Currently, only [filter](05-VirtualSources.md#filter-virtual-source-configuration) and


### PR DESCRIPTION
Major fixes:

- Make windowBy to be not just a column name but a spark sql expression. This allows for more advanced selection of custom columns for windowing
- Dataframe utils to prepare window and event timestamp columns are updated accordingly.
- Streamable virtual sources now allows to redefine windowBy column.
- Enable Avro format for kafka key and value message columns.

Minor fixes:

- Refactor dumpSize defaults for error collection: when dumpSize is missing in target configuration then application level dumpSize value is used.
- Weaken configuration validation requirements for spark parameter strings (enable string with various separators including new lines).
- Add debug logging for schemas (both during schema reading and during sources reading).
- Fix merge strategy rules for assembling dependencies uber-jar
- documentation updates to reflect aforementioned changes.