### PR TITLE
fix: minor code fixes

### DIFF
--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/IO.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/IO.scala
@@ -31,7 +31,8 @@ object IO {
   private def write[T](config: T, root: String, confName: String)
                       (implicit cw: ConfigWriter[T]): Result[Config] = 
     Try(cw.to(config).atKey(root)).toResult(
-      preMsg = s"Unable to write Data Quality $confName configuration to TypeSafe Config object with following error:"
+      preMsg = s"Unable to write Data Quality $confName configuration to TypeSafe Config object with following error:",
+      includeStackTrace = false
     )
 
   /**
@@ -63,7 +64,8 @@ object IO {
   private def read[T](input: T, confName: String)
                      (implicit p: ConfigParser[T]): Result[Config] =
     Try(p.parse(input)).toResult(
-      preMsg = s"Unable to read Data Quality $confName configuration into TypeSafe config object due to following error:"
+      preMsg = s"Unable to read Data Quality $confName configuration into TypeSafe config object due to following error:",
+      includeStackTrace = false
     )
 
   /**

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/connections/kafka/KafkaConnection.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/connections/kafka/KafkaConnection.scala
@@ -100,7 +100,7 @@ case class KafkaConnection(config: KafkaConnectionConfig) extends DQConnection w
         from_json(xmlToJson(col(colName).cast(StringType)), schemaGetter("XML").schema).alias(colName)
       case KafkaTopicFormat.Avro =>
         // intentionally use deprecated method to support compatibility with Spark 2.4.x versions.
-        from_avro(col(colName), schemaGetter("AVRO").toAvroSchema.toString).alias(colName)
+        from_avro(col(colName), schemaGetter("AVRO").toAvroSchema).alias(colName)
       case other => throw new IllegalArgumentException(
         s"Wrong kafka topic message format for column '$colName': ${other.toString}"
       )

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/context/DQStreamWindowJob.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/context/DQStreamWindowJob.scala
@@ -63,15 +63,15 @@ final case class DQStreamWindowJob(settings: AppSettings,
   private val bufferStage: String = RunStage.CheckProcessorBuffer.entryName
 
   /**
-   * Returns copy of the application settings object with reference and execution date being
-   * set for the provided window start time.
+   * Returns copy of the application settings object with modified execution and reference dates:
+   *   - reference date is set to the window start time
+   *   - execution date is set to current time (time when windows processing has started)
    *
    * @param windowId Window start time as unix epoch
    * @return Copy of the application settings with updated reference and execution datetime.
    */
   private def copySettings(windowId: Long): AppSettings = settings.copy(
-    executionDateTime = EnrichedDT.fromEpoch(
-      windowId, settings.executionDateTime.dateFormat, settings.executionDateTime.timeZone),
+    executionDateTime = settings.executionDateTime.resetToCurrentTime,
     referenceDateTime = EnrichedDT.fromEpoch(
       windowId, settings.referenceDateTime.dateFormat, settings.referenceDateTime.timeZone)
   )

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/utils/EnrichedDT.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/utils/EnrichedDT.scala
@@ -71,7 +71,15 @@ case class EnrichedDT(dateFormat: DateFormat, timeZone: ZoneId, dateString: Opti
   def getUtcTsWithOffset(offset: Duration): Timestamp = Timestamp.valueOf(
     zonedDT.minusSeconds(offset.toSeconds).withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime
   )
+
+  /**
+   * Returns a new EnrichedDT instance with the same date format and time zone, but with time
+   * being set to current time.
+   * @return New instance of EnrichedDT for current time.
+   */
+  def resetToCurrentTime: EnrichedDT = EnrichedDT(this.dateFormat, this.timeZone)
 }
+
 object EnrichedDT {
   /**
    * Builds EnrichedDT instance from Unix epoch (in seconds)

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/utils/ResultUtils.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/utils/ResultUtils.scala
@@ -32,7 +32,7 @@ object ResultUtils {
      * @param includeStackTrace Flag indicating whether to include error stack trace into log message
      * @return Result[T] with either result of error log message
      */
-    def toResult(preMsg: String = "", includeStackTrace: Boolean = false): Result[T] =
+    def toResult(preMsg: String = "", includeStackTrace: Boolean = true): Result[T] =
       value match {
         case Success(v) => Right(v)
         case Failure(e) =>


### PR DESCRIPTION
- when Avro schema is read from file then the original schema is stored as well to prevent unnecessary conversion.
- modify kafka column decoder for Avro topics
- change default arguments for `toResult` conversion method in order to retain error stack trace by default. Modify method invokes where stack trace is not needed.
- During windows processing the execution time will be set to actual time when window processing starts.