### PR TITLE
feat: new db table to store metric errors

### DIFF
--- a/checkita-core/src/main/resources/db/specific/h2/V1.4__add_metric_errors.sql
+++ b/checkita-core/src/main/resources/db/specific/h2/V1.4__add_metric_errors.sql
@@ -1,0 +1,14 @@
+/* no unique constraint for metric error table */
+CREATE TABLE "${defaultSchema}"."results_metric_error"
+(
+    "job_id"            VARCHAR(512)  NOT NULL,
+    "metric_id"         VARCHAR(512)  NOT NULL,
+    "source_id"         VARCHAR(512),
+    "source_key_fields" VARCHAR(2048),
+    "metric_columns"    VARCHAR(2048),
+    "status"            VARCHAR(512)  NOT NULL,
+    "message"           TEXT          NOT NULL,
+    "row_data"          TEXT          NOT NULL,
+    "reference_date"    TIMESTAMP     NOT NULL,
+    "execution_date"    TIMESTAMP     NOT NULL
+);

--- a/checkita-core/src/main/resources/db/specific/h2/V1.4__add_metric_errors.sql
+++ b/checkita-core/src/main/resources/db/specific/h2/V1.4__add_metric_errors.sql
@@ -1,4 +1,3 @@
-/* no unique constraint for metric error table */
 CREATE TABLE "${defaultSchema}"."results_metric_error"
 (
     "job_id"            VARCHAR(512)  NOT NULL,
@@ -9,6 +8,8 @@ CREATE TABLE "${defaultSchema}"."results_metric_error"
     "status"            VARCHAR(512)  NOT NULL,
     "message"           TEXT          NOT NULL,
     "row_data"          TEXT          NOT NULL,
+    "error_hash"        VARCHAR(512)  NOT NULL,
     "reference_date"    TIMESTAMP     NOT NULL,
-    "execution_date"    TIMESTAMP     NOT NULL
+    "execution_date"    TIMESTAMP     NOT NULL,
+    UNIQUE ("job_id", "error_hash", "reference_date")
 );

--- a/checkita-core/src/main/resources/db/specific/mssql/V1.4__add_metric_errors.sql
+++ b/checkita-core/src/main/resources/db/specific/mssql/V1.4__add_metric_errors.sql
@@ -1,0 +1,14 @@
+/* no unique constraint for metric error table */
+CREATE TABLE "${defaultSchema}"."results_metric_error"
+(
+    "job_id"            VARCHAR(512)  NOT NULL,
+    "metric_id"         VARCHAR(512)  NOT NULL,
+    "source_id"         VARCHAR(512),
+    "source_key_fields" VARCHAR(2048),
+    "metric_columns"    VARCHAR(2048),
+    "status"            VARCHAR(512)  NOT NULL,
+    "message"           VARCHAR(MAX)  NOT NULL,
+    "row_data"          VARCHAR(MAX)  NOT NULL,
+    "reference_date"    DATETIME      NOT NULL,
+    "execution_date"    DATETIME      NOT NULL
+);

--- a/checkita-core/src/main/resources/db/specific/mssql/V1.4__add_metric_errors.sql
+++ b/checkita-core/src/main/resources/db/specific/mssql/V1.4__add_metric_errors.sql
@@ -1,4 +1,3 @@
-/* no unique constraint for metric error table */
 CREATE TABLE "${defaultSchema}"."results_metric_error"
 (
     "job_id"            VARCHAR(512)  NOT NULL,
@@ -9,6 +8,8 @@ CREATE TABLE "${defaultSchema}"."results_metric_error"
     "status"            VARCHAR(512)  NOT NULL,
     "message"           VARCHAR(MAX)  NOT NULL,
     "row_data"          VARCHAR(MAX)  NOT NULL,
+    "error_hash"        VARCHAR(512)  NOT NULL,
     "reference_date"    DATETIME      NOT NULL,
-    "execution_date"    DATETIME      NOT NULL
+    "execution_date"    DATETIME      NOT NULL,
+    UNIQUE ("job_id", "error_hash", "reference_date")
 );

--- a/checkita-core/src/main/resources/db/specific/mysql/V1.3__add_version_info.sql
+++ b/checkita-core/src/main/resources/db/specific/mysql/V1.3__add_version_info.sql
@@ -10,7 +10,7 @@ CREATE TABLE "${defaultSchema}"."job_state"
 (
     "job_id"            VARCHAR(256)     NOT NULL,
     "config"            TEXT             NOT NULL,
-    "version_info"      VARCHAR(512      NOT NULL,
+    "version_info"      VARCHAR(512)     NOT NULL,
     "reference_date"    TIMESTAMP        NOT NULL,
     "execution_date"    TIMESTAMP        NOT NULL,
     UNIQUE ("job_id", "reference_date")

--- a/checkita-core/src/main/resources/db/specific/mysql/V1.4__add_metric_errors.sql
+++ b/checkita-core/src/main/resources/db/specific/mysql/V1.4__add_metric_errors.sql
@@ -1,0 +1,14 @@
+/* no unique constraint for metric error table */
+CREATE TABLE "${defaultSchema}"."results_metric_error"
+(
+    "job_id"            VARCHAR(256)   NOT NULL,
+    "metric_id"         VARCHAR(256)   NOT NULL,
+    "source_id"         VARCHAR(512),
+    "source_key_fields" VARCHAR(2048),
+    "metric_columns"    VARCHAR(2048),
+    "status"            VARCHAR(512)   NOT NULL,
+    "message"           TEXT           NOT NULL,
+    "row_data"          TEXT           NOT NULL,
+    "reference_date"    TIMESTAMP      NOT NULL,
+    "execution_date"    TIMESTAMP      NOT NULL
+);

--- a/checkita-core/src/main/resources/db/specific/mysql/V1.4__add_metric_errors.sql
+++ b/checkita-core/src/main/resources/db/specific/mysql/V1.4__add_metric_errors.sql
@@ -1,4 +1,3 @@
-/* no unique constraint for metric error table */
 CREATE TABLE "${defaultSchema}"."results_metric_error"
 (
     "job_id"            VARCHAR(256)   NOT NULL,
@@ -9,6 +8,8 @@ CREATE TABLE "${defaultSchema}"."results_metric_error"
     "status"            VARCHAR(512)   NOT NULL,
     "message"           TEXT           NOT NULL,
     "row_data"          TEXT           NOT NULL,
+    "error_hash"        VARCHAR(256)   NOT NULL,
     "reference_date"    TIMESTAMP      NOT NULL,
-    "execution_date"    TIMESTAMP      NOT NULL
+    "execution_date"    TIMESTAMP      NOT NULL,
+    UNIQUE ("job_id", "error_hash", "reference_date")
 );

--- a/checkita-core/src/main/resources/db/specific/oracle/V1.4__add_metric_errors.sql
+++ b/checkita-core/src/main/resources/db/specific/oracle/V1.4__add_metric_errors.sql
@@ -1,4 +1,3 @@
-/* no unique constraint for metric error table */
 CREATE TABLE "${defaultSchema}"."results_metric_error"
 (
     "job_id"            VARCHAR(512)   NOT NULL,
@@ -9,6 +8,8 @@ CREATE TABLE "${defaultSchema}"."results_metric_error"
     "status"            VARCHAR(512)   NOT NULL,
     "message"           CLOB           NOT NULL,
     "row_data"          CLOB           NOT NULL,
+    "error_hash"        VARCHAR(512)   NOT NULL,
     "reference_date"    TIMESTAMP      NOT NULL,
-    "execution_date"    TIMESTAMP      NOT NULL
+    "execution_date"    TIMESTAMP      NOT NULL,
+    UNIQUE ("job_id", "error_hash", "reference_date")
 );

--- a/checkita-core/src/main/resources/db/specific/oracle/V1.4__add_metric_errors.sql
+++ b/checkita-core/src/main/resources/db/specific/oracle/V1.4__add_metric_errors.sql
@@ -1,0 +1,14 @@
+/* no unique constraint for metric error table */
+CREATE TABLE "${defaultSchema}"."results_metric_error"
+(
+    "job_id"            VARCHAR(512)   NOT NULL,
+    "metric_id"         VARCHAR(512)   NOT NULL,
+    "source_id"         VARCHAR(512),
+    "source_key_fields" VARCHAR(2048),
+    "metric_columns"    VARCHAR(2048),
+    "status"            VARCHAR(512)   NOT NULL,
+    "message"           CLOB           NOT NULL,
+    "row_data"          CLOB           NOT NULL,
+    "reference_date"    TIMESTAMP      NOT NULL,
+    "execution_date"    TIMESTAMP      NOT NULL
+);

--- a/checkita-core/src/main/resources/db/specific/postgres/V1.4__add_metric_errors.sql
+++ b/checkita-core/src/main/resources/db/specific/postgres/V1.4__add_metric_errors.sql
@@ -1,0 +1,15 @@
+/* no unique constraint for metric error table */
+CREATE TABLE "${defaultSchema}"."results_metric_error"
+(
+    "job_id"            TEXT      NOT NULL,
+    "metric_id"         TEXT      NOT NULL,
+    "source_id"         TEXT,
+    "source_key_fields" TEXT,
+    "metric_columns"    TEXT,
+    "status"            TEXT      NOT NULL,
+    "message"           TEXT      NOT NULL,
+    "row_data"          TEXT      NOT NULL,
+    "reference_date"    TIMESTAMP NOT NULL,
+    "execution_date"    TIMESTAMP NOT NULL
+    --, UNIQUE ("job_id", "metric_id", "status", "message", "row_data", "reference_date")
+);

--- a/checkita-core/src/main/resources/db/specific/postgres/V1.4__add_metric_errors.sql
+++ b/checkita-core/src/main/resources/db/specific/postgres/V1.4__add_metric_errors.sql
@@ -1,4 +1,3 @@
-/* no unique constraint for metric error table */
 CREATE TABLE "${defaultSchema}"."results_metric_error"
 (
     "job_id"            TEXT      NOT NULL,
@@ -9,7 +8,8 @@ CREATE TABLE "${defaultSchema}"."results_metric_error"
     "status"            TEXT      NOT NULL,
     "message"           TEXT      NOT NULL,
     "row_data"          TEXT      NOT NULL,
+    "error_hash"        TEXT      NOT NULL,
     "reference_date"    TIMESTAMP NOT NULL,
-    "execution_date"    TIMESTAMP NOT NULL
-    --, UNIQUE ("job_id", "metric_id", "status", "message", "row_data", "reference_date")
+    "execution_date"    TIMESTAMP NOT NULL,
+    UNIQUE ("job_id", "error_hash", "reference_date")
 );

--- a/checkita-core/src/main/resources/db/specific/sqlite/V1.1__create_job_state.sql
+++ b/checkita-core/src/main/resources/db/specific/sqlite/V1.1__create_job_state.sql
@@ -4,5 +4,5 @@ CREATE TABLE "job_state"
     "config"            TEXT             NOT NULL,
     "reference_date"    TIMESTAMP        NOT NULL,
     "execution_date"    TIMESTAMP        NOT NULL,
-    UNIQUE ("job_id", "reference_date")
+    UNIQUE ("job_id", "reference_date") ON CONFLICT REPLACE
 );

--- a/checkita-core/src/main/resources/db/specific/sqlite/V1.3__add_version_info.sql
+++ b/checkita-core/src/main/resources/db/specific/sqlite/V1.3__add_version_info.sql
@@ -6,7 +6,7 @@ CREATE TABLE "job_state"
     "version_info"      TEXT             NOT NULL,
     "reference_date"    TIMESTAMP        NOT NULL,
     "execution_date"    TIMESTAMP        NOT NULL,
-    UNIQUE ("job_id", "reference_date")
+    UNIQUE ("job_id", "reference_date") ON CONFLICT REPLACE
 );
 INSERT INTO "job_state" (
     "job_id",

--- a/checkita-core/src/main/resources/db/specific/sqlite/V1.4__add_metric_errors.sql
+++ b/checkita-core/src/main/resources/db/specific/sqlite/V1.4__add_metric_errors.sql
@@ -1,0 +1,14 @@
+/* no unique constraint for metric error table */
+CREATE TABLE "results_metric_error"
+(
+    "job_id"            TEXT      NOT NULL,
+    "metric_id"         TEXT      NOT NULL,
+    "source_id"         TEXT,
+    "source_key_fields" TEXT,
+    "metric_columns"    TEXT,
+    "status"            TEXT      NOT NULL,
+    "message"           TEXT      NOT NULL,
+    "row_data"          TEXT      NOT NULL,
+    "reference_date"    TIMESTAMP NOT NULL,
+    "execution_date"    TIMESTAMP NOT NULL
+);

--- a/checkita-core/src/main/resources/db/specific/sqlite/V1.4__add_metric_errors.sql
+++ b/checkita-core/src/main/resources/db/specific/sqlite/V1.4__add_metric_errors.sql
@@ -1,4 +1,3 @@
-/* no unique constraint for metric error table */
 CREATE TABLE "results_metric_error"
 (
     "job_id"            TEXT      NOT NULL,
@@ -9,6 +8,8 @@ CREATE TABLE "results_metric_error"
     "status"            TEXT      NOT NULL,
     "message"           TEXT      NOT NULL,
     "row_data"          TEXT      NOT NULL,
+    "error_hash"        TEXT      NOT NULL,
     "reference_date"    TIMESTAMP NOT NULL,
-    "execution_date"    TIMESTAMP NOT NULL
+    "execution_date"    TIMESTAMP NOT NULL,
+    UNIQUE ("job_id", "error_hash", "reference_date") ON CONFLICT REPLACE
 );

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/appsettings/AppSettings.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/appsettings/AppSettings.scala
@@ -22,7 +22,8 @@ import scala.util.Try
  * @param aggregatedKafkaOutput Enables sending aggregates messages for Kafka Targets
  *                              (one per each target type, except checkAlerts where
  *                              one message per checkAlert will be sent)
- * @param enableCaseSensitivity Enable columns case sensitivity
+ * @param enableCaseSensitivity Enables columns case sensitivity
+ * @param saveErrorsToStorage   Enables metric errors to be stored in storage database.
  * @param errorDumpSize         Maximum number of errors to be collected per single metric.
  * @param outputRepartition     Sets the number of partitions when writing outputs. By default writes single file.
  * @param storageConfig         Configuration of connection to Data Quality Storage
@@ -46,6 +47,7 @@ final case class AppSettings(
                               allowSqlQueries: Boolean,
                               aggregatedKafkaOutput: Boolean,
                               enableCaseSensitivity: Boolean,
+                              saveErrorsToStorage: Boolean,
                               errorDumpSize: Int,
                               outputRepartition: Int,
                               storageConfig: Option[StorageConfig],
@@ -129,6 +131,7 @@ object AppSettings {
         appConfig.enablers.allowSqlQueries,
         appConfig.enablers.aggregatedKafkaOutput,
         appConfig.enablers.enableCaseSensitivity,
+        appConfig.enablers.saveErrorsToStorage,
         appConfig.enablers.errorDumpSize.value,
         appConfig.enablers.outputRepartition.value,
         appConfig.storage,
@@ -203,6 +206,7 @@ object AppSettings {
       defaultAppConf.enablers.allowSqlQueries,
       defaultAppConf.enablers.aggregatedKafkaOutput,
       defaultAppConf.enablers.enableCaseSensitivity,
+      defaultAppConf.enablers.saveErrorsToStorage,
       defaultAppConf.enablers.errorDumpSize.value,
       defaultAppConf.enablers.outputRepartition.value,
       defaultAppConf.storage,

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/appsettings/AppSettings.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/appsettings/AppSettings.scala
@@ -23,7 +23,6 @@ import scala.util.Try
  *                              (one per each target type, except checkAlerts where
  *                              one message per checkAlert will be sent)
  * @param enableCaseSensitivity Enables columns case sensitivity
- * @param saveErrorsToStorage   Enables metric errors to be stored in storage database.
  * @param errorDumpSize         Maximum number of errors to be collected per single metric.
  * @param outputRepartition     Sets the number of partitions when writing outputs. By default writes single file.
  * @param storageConfig         Configuration of connection to Data Quality Storage
@@ -47,7 +46,6 @@ final case class AppSettings(
                               allowSqlQueries: Boolean,
                               aggregatedKafkaOutput: Boolean,
                               enableCaseSensitivity: Boolean,
-                              saveErrorsToStorage: Boolean,
                               errorDumpSize: Int,
                               outputRepartition: Int,
                               storageConfig: Option[StorageConfig],
@@ -131,7 +129,6 @@ object AppSettings {
         appConfig.enablers.allowSqlQueries,
         appConfig.enablers.aggregatedKafkaOutput,
         appConfig.enablers.enableCaseSensitivity,
-        appConfig.enablers.saveErrorsToStorage,
         appConfig.enablers.errorDumpSize.value,
         appConfig.enablers.outputRepartition.value,
         appConfig.storage,
@@ -206,7 +203,6 @@ object AppSettings {
       defaultAppConf.enablers.allowSqlQueries,
       defaultAppConf.enablers.aggregatedKafkaOutput,
       defaultAppConf.enablers.enableCaseSensitivity,
-      defaultAppConf.enablers.saveErrorsToStorage,
       defaultAppConf.enablers.errorDumpSize.value,
       defaultAppConf.enablers.outputRepartition.value,
       defaultAppConf.storage,

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/Enablers.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/Enablers.scala
@@ -12,6 +12,9 @@ import eu.timepit.refined.auto._
  *                              (one per each target type, except checkAlerts where
  *                              one message per checkAlert will be sent)
  * @param enableCaseSensitivity Enable columns case sensitivity
+ * @param saveErrorsToStorage Enables metric errors to be stored in storage database.
+ *                            Be careful when storing metric errors in storage database
+ *                            as this might overload the storage.
  * @param errorDumpSize Maximum number of errors to be collected per single metric per partition.
  * @param outputRepartition Sets the number of partitions when writing outputs. By default writes single file.
  */
@@ -20,6 +23,7 @@ final case class Enablers(
                            allowNotifications: Boolean = false,
                            aggregatedKafkaOutput: Boolean = false,
                            enableCaseSensitivity: Boolean = false,
+                           saveErrorsToStorage: Boolean = false,
                            errorDumpSize: PositiveInt = 10000,
                            outputRepartition: PositiveInt = 1
                          )

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/Enablers.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/Enablers.scala
@@ -6,24 +6,20 @@ import eu.timepit.refined.auto._
 /**
  * Application-level configuration for switchers (enablers)
  *
- * @param allowSqlQueries Enables arbitrary SQL queries in virtual sources
- * @param allowNotifications Enables notifications to be sent from DQ application
+ * @param allowSqlQueries       Enables arbitrary SQL queries in virtual sources
+ * @param allowNotifications    Enables notifications to be sent from DQ application
  * @param aggregatedKafkaOutput Enables sending aggregates messages for Kafka Targets
  *                              (one per each target type, except checkAlerts where
  *                              one message per checkAlert will be sent)
  * @param enableCaseSensitivity Enable columns case sensitivity
- * @param saveErrorsToStorage Enables metric errors to be stored in storage database.
- *                            Be careful when storing metric errors in storage database
- *                            as this might overload the storage.
- * @param errorDumpSize Maximum number of errors to be collected per single metric per partition.
- * @param outputRepartition Sets the number of partitions when writing outputs. By default writes single file.
+ * @param errorDumpSize         Maximum number of errors to be collected per single metric per partition.
+ * @param outputRepartition     Sets the number of partitions when writing outputs. By default writes single file.
  */
 final case class Enablers(
                            allowSqlQueries: Boolean = false,
                            allowNotifications: Boolean = false,
                            aggregatedKafkaOutput: Boolean = false,
                            enableCaseSensitivity: Boolean = false,
-                           saveErrorsToStorage: Boolean = false,
                            errorDumpSize: PositiveInt = 10000,
                            outputRepartition: PositiveInt = 1
                          )

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/Encryption.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/Encryption.scala
@@ -6,10 +6,13 @@ import ru.raiffeisen.checkita.config.RefinedTypes.EncryptionKey
 /**
  * Application-level configuration describing encryption sensitive fields
  *
- * @param secret Secret string used to encrypt/decrypt sensitive fields
- * @param keyFields List of key fields used to identify fields that requires encryption/decryption.
+ * @param secret           Secret string used to encrypt/decrypt sensitive fields
+ * @param keyFields        List of key fields used to identify fields that requires encryption/decryption.
+ * @param encryptErrorData Boolean flag indicating whether rowData (contains excerpts from data sources)
+ *                         field in metric errors should be encrypted.
  */
 final case class Encryption(
                              secret: EncryptionKey,
-                             keyFields: Seq[String] = Seq("password", "secret")
+                             keyFields: Seq[String] = Seq("password", "secret"),
+                             encryptErrorData: Boolean = false
                            )

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/StorageConfig.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/appconf/StorageConfig.scala
@@ -6,17 +6,22 @@ import ru.raiffeisen.checkita.config.Enums.DQStorageType
 
 /**
  * Application-level configuration describing connection to history database.
- * @param dbType Type of database used to store DQ data (one of the supported RDBMS)
- * @param url Connection URL (without protocol identifiers)
- * @param username Username to connect to database with (if required)
- * @param password Password to connect to database with (if required)
- * @param schema Schema where data quality tables are located (if required)
+ *
+ * @param dbType              Type of database used to store DQ data (one of the supported RDBMS)
+ * @param url                 Connection URL (without protocol identifiers)
+ * @param username            Username to connect to database with (if required)
+ * @param password            Password to connect to database with (if required)
+ * @param schema              Schema where data quality tables are located (if required)
+ * @param saveErrorsToStorage Enables metric errors to be stored in storage database.
+ *                            Be careful when storing metric errors in storage database
+ *                            as this might overload the storage.
  */
 final case class StorageConfig(
                                 dbType: DQStorageType,
                                 url: URI,
                                 username: Option[NonEmptyString],
                                 password: Option[NonEmptyString],
-                                schema: Option[NonEmptyString]
+                                schema: Option[NonEmptyString],
+                                saveErrorsToStorage: Boolean = false
                               )
 

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/context/DQContext.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/context/DQContext.scala
@@ -95,6 +95,7 @@ class DQContext(settings: AppSettings, spark: SparkSession, fs: FileSystem) exte
       s"  - allowSqlQueries:          ${settings.allowSqlQueries}",
       s"  - aggregatedKafkaOutput:    ${settings.aggregatedKafkaOutput}",
       s"  - enableCaseSensitivity:    ${settings.enableCaseSensitivity}",
+      s"  - saveErrorsToStorage:      ${settings.saveErrorsToStorage}",
       s"  - errorDumpSize:            ${settings.errorDumpSize}",
       s"  - outputRepartition:        ${settings.outputRepartition}"   
     )
@@ -147,6 +148,14 @@ class DQContext(settings: AppSettings, spark: SparkSession, fs: FileSystem) exte
       "* Extra variables:",
       s"  - List of all available variables (values are not shown intentionally): $extraVarsList"
     )
+
+    val encryptionKeyFields = settings.encryption.map(e => e.keyFields.mkString("[", ", ", "]"))
+    val logEncryption = Seq(
+      "* Encryption configuration:",
+      encryptionKeyFields.map(kf =>
+        s"  - Encrypt configuration keys that contain following substrings: $kf"
+      ).getOrElse("Encryption configuration is not set. The job state will be saved as is.")
+    )
     
     (
       logGeneral ++ 
@@ -157,7 +166,8 @@ class DQContext(settings: AppSettings, spark: SparkSession, fs: FileSystem) exte
       logStorageConf ++ 
       logEmailConfig ++ 
       logMMConfig ++
-      logExtraVars
+      logExtraVars ++
+      logEncryption
     ).foreach(msg => log.info(s"$settingsStage $msg"))
   }
 

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/Results.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/Results.scala
@@ -116,18 +116,26 @@ object Results {
         settings.executionDateTime.getUtcTS
       )
 
+    /**
+     * Retrieves sequence of finalized metric errors from metric calculator result
+     * that is suitable for storing into results storage and sending via targets.
+     *
+     * @param jobId    Implicit Job ID
+     * @param settings Implicit application settings object
+     * @return Sequence of finalized metric errors
+     */
     def finalizeMetricErrors(implicit jobId: String,
-                             settings: AppSettings): Seq[ResultMetricErrors] = 
+                             settings: AppSettings): Seq[ResultMetricError] =
       errors.toSeq.flatMap{ err => 
-        err.errors.map(e => ResultMetricErrors(
+        err.errors.map(e => ResultMetricError(
           jobId,
           metricId,
-          sourceIds,
-          sourceKeyFields,
-          columns,
+          write(sourceIds),
+          write(sourceKeyFields),
+          write(columns),
           e.status.toString,
           e.message,
-          err.columns.zip(e.rowData).toMap,
+          write(err.columns.zip(e.rowData).toMap),
           settings.referenceDateTime.getUtcTS,
           settings.executionDateTime.getUtcTS
         ))
@@ -136,16 +144,17 @@ object Results {
 
   /**
    * Check calculator result.
-   * @param checkId Check ID
-   * @param checkName Check calculator name
-   * @param baseMetric Base metric used to build check
-   * @param comparedMetric Metric to compare with
+   *
+   * @param checkId           Check ID
+   * @param checkName         Check calculator name
+   * @param baseMetric        Base metric used to build check
+   * @param comparedMetric    Metric to compare with
    * @param comparedThreshold Threshold to compare with
-   * @param lowerBound Allowed lower bound for base metric value
-   * @param upperBound Allowed upper bound for base metric value
-   * @param status Check status
-   * @param message Check message
-   * @param resultType Type of result
+   * @param lowerBound        Allowed lower bound for base metric value
+   * @param upperBound        Allowed upper bound for base metric value
+   * @param status            Check status
+   * @param message           Check message
+   * @param resultType        Type of result
    */
   final case class CheckCalculatorResult(
                                           checkId: String,
@@ -194,12 +203,13 @@ object Results {
 
   /**
    * Load check calculator result
-   * @param checkId Check ID
-   * @param checkName Load check calculator name
-   * @param sourceId Source ID
-   * @param expected Expected value
-   * @param status Check status
-   * @param message Check message
+   *
+   * @param checkId    Check ID
+   * @param checkName  Load check calculator name
+   * @param sourceId   Source ID
+   * @param expected   Expected value
+   * @param status     Check status
+   * @param message    Check message
    * @param resultType Type of result
    */
   final case class LoadCheckCalculatorResult(

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/Source.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/Source.scala
@@ -19,3 +19,21 @@ case class Source(
                  ) {
   val isStreaming: Boolean = df.isStreaming
 }
+object Source {
+  def validated(id: String,
+                df: DataFrame,
+                keyFields: Seq[String] = Seq.empty,
+                parents: Seq[String] = Seq.empty)(implicit caseSensitive: Boolean): Source = {
+
+    val kf = if (caseSensitive) keyFields else keyFields.map(_.toLowerCase)
+    val cols = if (caseSensitive) df.columns else df.columns.map(_.toLowerCase)
+    val missedKf = kf.filterNot(cols.contains)
+    require(
+      missedKf.isEmpty,
+      s"Some of key fields were not found for source '$id'. " +
+        "Following keyFields are not found within source columns: " +
+        missedKf.mkString("[`", "`, `", "`]")
+    )
+    Source(id, df, kf, parents)
+  }
+}

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/MetricBatchProcessor.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/MetricBatchProcessor.scala
@@ -49,7 +49,9 @@ object MetricBatchProcessor extends MetricProcessor {
 
     assert(
       sourceKeys.size == sourceKeyIds.size,
-      s"Some of key fields were not found for source '${source.id}'. Please, check them."
+      s"Some of key fields were not found for source '${source.id}'. " +
+      "Following keyFields are not found within source columns: " +
+        sourceKeys.filterNot(columnIndexes.contains).mkString("[`", "`, `", "`]")
     )
 
     val metricsByColumns = sourceMetrics.groupBy(

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/MetricStreamProcessor.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/MetricStreamProcessor.scala
@@ -107,7 +107,9 @@ object MetricStreamProcessor extends MetricProcessor with Logging {
       assert(
         streamKeys.size == streamKeyIds.size,
         s"Some of key fields were not found for stream '$streamId' in batch $batchId. " +
-          s"Please ensure that keyFields are always exist within streamed messages."
+        "Following keyFields are not found within stream columns: " +
+        streamKeys.filterNot(columnIndexes.contains).mkString("[`", "`, `", "`]") +
+        s". Please ensure that keyFields are always exist within streamed messages."
       )
 
       val metricsByColumns = streamMetrics.groupBy(

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/readers/SourceReaders.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/readers/SourceReaders.scala
@@ -131,7 +131,7 @@ object SourceReaders {
         case ReadMode.Batch =>
           val batchReader = spark.read.format(format.toLowerCase)
           if (format.toLowerCase == "avro")
-            schema.map(sch => batchReader.option("avroSchema", sch.toAvroSchema.toString))
+            schema.map(sch => batchReader.option("avroSchema", sch.toAvroSchema))
               .getOrElse(batchReader).load(path)
           else schema.map(sch => batchReader.schema(sch.schema)).getOrElse(batchReader).load(path)
         case ReadMode.Stream =>
@@ -293,7 +293,7 @@ object SourceReaders {
         preDf.filter(
           config.partitions.map { p =>
             if (p.expr.nonEmpty) p.expr.get
-            else col(p.name.value).isin(p.values.map(_.value))
+            else col(p.name.value).isin(p.values.map(_.value): _*)
           }.reduce(_ && _)
         )
       } else preDf

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/readers/SourceReaders.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/readers/SourceReaders.scala
@@ -37,8 +37,10 @@ object SourceReaders {
      * @param df Spark Dataframe
      * @return Source
      */
-    protected def toSource(config: T, df: DataFrame): Source = 
-      Source(config.id.value, df, config.keyFields.map(_.value))
+    protected def toSource(config: T, df: DataFrame)
+                          (implicit settings: AppSettings): Source = {
+      Source.validated(config.id.value, df, config.keyFields.map(_.value))(settings.enableCaseSensitivity)
+    }
 
     /**
      * Tries to read source given the source configuration.
@@ -57,10 +59,10 @@ object SourceReaders {
      */
     def tryToRead(config: T,
                   readMode: ReadMode)(implicit settings: AppSettings,
-                                                spark: SparkSession,
-                                                fs: FileSystem,
-                                                schemas: Map[String, SourceSchema],
-                                                connections: Map[String, DQConnection]): Source
+                                      spark: SparkSession,
+                                      fs: FileSystem,
+                                      schemas: Map[String, SourceSchema],
+                                      connections: Map[String, DQConnection]): Source
 
     /**
      * Safely reads source given source configuration.

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/readers/VirtualSourceReaders.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/readers/VirtualSourceReaders.scala
@@ -61,7 +61,9 @@ object VirtualSourceReaders {
         val df = getDataFrame(config, readMode)
         // persist if necessary:
         if (config.persist.nonEmpty) df.persist(config.persist.get)
-        Source(config.id.value, df, config.keyFields.map(_.value), config.parents)
+        Source.validated(
+          config.id.value, df, config.keyFields.map(_.value), config.parents
+        )(settings.enableCaseSensitivity)
       }.toResult(
         preMsg = s"Unable to read virtual source '${config.id.value}' due to following error: "
       )

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/storage/Connections.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/storage/Connections.scala
@@ -11,7 +11,7 @@ import javax.sql.DataSource
 object Connections {
 
   sealed abstract class DqStorageConnection {
-    protected val config: StorageConfig
+    val config: StorageConfig
     def getType: DQStorageType = config.dbType
   }
   

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/storage/Models.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/storage/Models.scala
@@ -1,11 +1,10 @@
 package ru.raiffeisen.checkita.storage
 
-import ru.raiffeisen.checkita.appsettings.{AppSettings, VersionInfo}
+import ru.raiffeisen.checkita.appsettings.AppSettings
 import ru.raiffeisen.checkita.core.CalculatorStatus
 import ru.raiffeisen.checkita.utils.Common.camelToSnakeCase
 import shapeless.{::, HList, HNil}
 
-import java.security.MessageDigest
 import java.sql.Timestamp
 
 // store arrays as string: '[val1, val2, val3]'
@@ -135,20 +134,12 @@ object Models {
                                      status: String,
                                      message: String,
                                      rowData: String,
+                                     errorHash: String,
                                      referenceDate: Timestamp,
                                      executionDate: Timestamp) extends DQEntity {
-    override val uniqueFields: HList = jobId :: metricId :: status :: message :: rowData :: referenceDate :: HNil
-    override val uniqueFieldNames: Seq[String] =
-      Seq("jobId", "metricId", "referenceDate", "status", "message", "rowData").map(camelToSnakeCase)
+    override val uniqueFields: HList = jobId :: errorHash :: referenceDate :: HNil
+    override val uniqueFieldNames: Seq[String] = Seq("jobId", "errorHash", "referenceDate").map(camelToSnakeCase)
     val entityType: String = "metricError"
-
-    /**
-     * Use this key to deduplicate sequence of metric errors
-     */
-    def groupingKey: String = {
-      val uniqueFieldsStr = jobId + metricId + status + message + rowData + referenceDate.toString
-      MessageDigest.getInstance("MD5").digest(uniqueFieldsStr.getBytes).map("%02x".format(_)).mkString
-    }
   }
 
   final case class ResultSummaryMetrics(

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/storage/Tables.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/storage/Tables.scala
@@ -12,7 +12,12 @@ class Tables(val profile: JdbcProfile) {
   
   sealed abstract class DQTable[R <: DQEntity](tag: Tag, schema: Option[String], table: String)
       extends Table[R](tag, schema, table) {
-    def jobId: Rep[String] = column[String]("job_id") // mandatory for all entities.
+
+    // columns that are mandatory for all entities:
+    def jobId: Rep[String] = column[String]("job_id")
+    def referenceDate: Rep[Timestamp] = column[Timestamp]("reference_date")
+    def executionDate: Rep[Timestamp] = column[Timestamp]("execution_date")
+
     def getUniqueCond(r: R): Rep[Boolean]
   }
 
@@ -37,8 +42,6 @@ class Tables(val profile: JdbcProfile) {
     def sourceId: Rep[String] = column[String]("source_id")
     def result: Rep[Double] = column[Double]("result")
     def additionalResult: Rep[Option[String]] = column[Option[String]]("additional_result")
-    def referenceDate: Rep[Timestamp] = column[Timestamp]("reference_date")
-    def executionDate: Rep[Timestamp] = column[Timestamp]("execution_date")
 
     def getUniqueCond(r: R): Rep[Boolean] =
       jobId === r.jobId && metricId === r.metricId && referenceDate === r.referenceDate
@@ -52,8 +55,6 @@ class Tables(val profile: JdbcProfile) {
     def sourceId: Rep[String] = column[String]("source_id")
     def status: Rep[String] = column[String]("status")
     def message: Rep[Option[String]] = column[Option[String]]("message")
-    def referenceDate: Rep[Timestamp] = column[Timestamp]("reference_date")
-    def executionDate: Rep[Timestamp] = column[Timestamp]("execution_date")
 
     def getUniqueCond(r: R): Rep[Boolean] =
       jobId === r.jobId && checkId === r.checkId && referenceDate === r.referenceDate
@@ -149,13 +150,46 @@ class Tables(val profile: JdbcProfile) {
     ) <> (ResultCheckLoad.tupled, ResultCheckLoad.unapply)
   }
 
+  class ResultMetricErrorTable(tag: Tag, schema: Option[String])
+    extends DQTable[ResultMetricError](tag, schema, "results_metric_error") {
+
+
+    def metricId: Rep[String] = column[String]("metric_id")
+    def sourceId: Rep[String] = column[String]("source_id")
+    def sourceKeyFields: Rep[String] = column[String]("source_key_fields")
+    def metricColumns: Rep[String] = column[String]("metric_columns")
+    def status: Rep[String] = column[String]("status")
+    def message: Rep[String] = column[String]("message")
+    def rowData: Rep[String] = column[String]("row_data")
+
+    def getUniqueCond(r: ResultMetricError): Rep[Boolean] = (
+      jobId === r.jobId &&
+      metricId === r.metricId &&
+      status === r.status &&
+      message === r.message &&
+      rowData === r.rowData &&
+      referenceDate === r.referenceDate
+    )
+
+    def * : ProvenShape[ResultMetricError] = (
+      jobId,
+      metricId,
+      sourceId,
+      sourceKeyFields,
+      metricColumns,
+      status,
+      message,
+      rowData,
+      referenceDate,
+      executionDate
+    ) <> (ResultMetricError.tupled, ResultMetricError.unapply)
+  }
+
   class JobStateTable(tag: Tag, schema: Option[String])
     extends DQTable[JobState](tag, schema, "job_state") {
 
     def config: Rep[String] = column[String]("config")
     def versionInfo: Rep[String] = column[String]("version_info")
-    def referenceDate: Rep[Timestamp] = column[Timestamp]("reference_date")
-    def executionDate: Rep[Timestamp] = column[Timestamp]("execution_date")
 
     def getUniqueCond(r: JobState): Rep[Boolean] =
       jobId === r.jobId && referenceDate === r.referenceDate
@@ -192,6 +226,13 @@ class Tables(val profile: JdbcProfile) {
       type T = ResultCheckLoadTable
       def getTableQuery(schema: Option[String]): TableQuery[ResultCheckLoadTable] =
         TableQuery[ResultCheckLoadTable]((t: Tag) => new ResultCheckLoadTable(t, schema))
+    }
+
+    implicit object ResultMetricErrorTableOps extends DQTableOps[ResultMetricError] {
+      type T = ResultMetricErrorTable
+
+      def getTableQuery(schema: Option[String]): TableQuery[ResultMetricErrorTable] =
+        TableQuery[ResultMetricErrorTable]((t: Tag) => new ResultMetricErrorTable(t, schema))
     }
 
     implicit object JobStateTableOps extends DQTableOps[JobState] {

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/storage/Tables.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/storage/Tables.scala
@@ -161,15 +161,10 @@ class Tables(val profile: JdbcProfile) {
     def status: Rep[String] = column[String]("status")
     def message: Rep[String] = column[String]("message")
     def rowData: Rep[String] = column[String]("row_data")
+    def errorHash: Rep[String] = column[String]("error_hash")
 
-    def getUniqueCond(r: ResultMetricError): Rep[Boolean] = (
-      jobId === r.jobId &&
-      metricId === r.metricId &&
-      status === r.status &&
-      message === r.message &&
-      rowData === r.rowData &&
-      referenceDate === r.referenceDate
-    )
+    def getUniqueCond(r: ResultMetricError): Rep[Boolean] =
+      jobId === r.jobId && errorHash === r.errorHash && referenceDate === r.referenceDate
 
     def * : ProvenShape[ResultMetricError] = (
       jobId,
@@ -180,6 +175,7 @@ class Tables(val profile: JdbcProfile) {
       status,
       message,
       rowData,
+      errorHash,
       referenceDate,
       executionDate
     ) <> (ResultMetricError.tupled, ResultMetricError.unapply)

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/BuildHelpers.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/BuildHelpers.scala
@@ -1,6 +1,6 @@
 package ru.raiffeisen.checkita.targets.builders
 
-import ru.raiffeisen.checkita.storage.Models.ResultMetricErrors
+import ru.raiffeisen.checkita.storage.Models.ResultMetricError
 
 import scala.util.Try
 
@@ -14,9 +14,9 @@ trait BuildHelpers {
    * @return Filtered sequence of metric errors
    * @note If requested metric IDs are not provided (sequence is empty) then errors for all metrics are returned.
    */
-  def filterErrors(errors: Seq[ResultMetricErrors],
+  def filterErrors(errors: Seq[ResultMetricError],
                    requested: Seq[String],
-                   dumpSize: Int): Seq[ResultMetricErrors] =
+                   dumpSize: Int): Seq[ResultMetricError] =
     errors
       .filter(r => if (requested.isEmpty) true else requested.contains(r.metricId))
       .groupBy(_.metricId)

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/notification/NotificationBuilder.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/targets/builders/notification/NotificationBuilder.scala
@@ -4,7 +4,7 @@ import ru.raiffeisen.checkita.appsettings.AppSettings
 import ru.raiffeisen.checkita.config.Enums.TemplateFormat
 import ru.raiffeisen.checkita.connections.BinaryAttachment
 import ru.raiffeisen.checkita.core.CalculatorStatus
-import ru.raiffeisen.checkita.storage.Models.{CheckResult, ResultMetricErrors, ResultSummaryMetrics}
+import ru.raiffeisen.checkita.storage.Models.{CheckResult, ResultMetricError, ResultSummaryMetrics}
 import ru.raiffeisen.checkita.storage.Serialization._
 import ru.raiffeisen.checkita.targets.builders.BuildHelpers
 import ru.raiffeisen.checkita.utils.Templating.renderTemplate
@@ -31,7 +31,7 @@ trait NotificationBuilder extends BuildHelpers {
       renderTemplate(finalTemplate, summaryMetrics.getFieldsMap)
     }
 
-  protected def buildErrorsAttachment(errors: Seq[ResultMetricErrors],
+  protected def buildErrorsAttachment(errors: Seq[ResultMetricError],
                                       requested: Seq[String],
                                       dumpSize: Int)(implicit settings: AppSettings): Option[BinaryAttachment] = {
     filterErrors(errors, requested, dumpSize) match {

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/utils/ResultUtils.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/utils/ResultUtils.scala
@@ -81,6 +81,20 @@ object ResultUtils {
      */
     def toResult(f: L => Vector[String]): Result[R] = mapLeft[Vector[String]](f)
   }
+
+  implicit class OptionOps[T](value: Option[T]) {
+    /**
+     * Converts Option[T] into a Result[T]
+     *
+     * @param preMsg            Additional descriptive message added to error message
+     * @return Result[T] with either result or error log message
+     */
+    def toResult(preMsg: String = ""): Result[T] =
+      value match {
+        case Some(v) => Right(v)
+        case None => Left(Vector(s"$preMsg\nOption value is absent"))
+      }
+  }
   
   /**
    * Implicit conversion for Result[T] with some extra methods

--- a/checkita-core/src/test/scala/ru/raiffeisen/checkita/readers/VirtualSourceReader.scala
+++ b/checkita-core/src/test/scala/ru/raiffeisen/checkita/readers/VirtualSourceReader.scala
@@ -34,7 +34,7 @@ class VirtualSourceReader extends AnyWordSpec with Matchers {
         "select id, name, entity, description from hive_source_1 where dlk_cob_date == '2023-06-30'",
         Option(StorageLevel.DISK_ONLY),
         Option(OrcFileOutputConfig("tmp/DQ/sqlVS")),
-        Seq("batchId")
+        Seq("id")
       )
 
       val sqlVirtualSource = SqlVirtualSourceReader.read(sqlConfig, parentSources, ReadMode.Batch)
@@ -61,7 +61,7 @@ class VirtualSourceReader extends AnyWordSpec with Matchers {
         "sele id, name, entity, description from hive_source_1 where dlk_cob_date == '2023-06-30'",
         Option(StorageLevel.DISK_ONLY),
         Option(OrcFileOutputConfig("tmp/DQ/sqlVS")),
-        Seq("batchId")
+        Seq("id")
       )
 
       val sqlVirtualSource = SqlVirtualSourceReader.read(sqlConfig, parentSources, ReadMode.Batch)
@@ -88,7 +88,7 @@ class VirtualSourceReader extends AnyWordSpec with Matchers {
         SparkJoinType.Left,
         Option(StorageLevel.MEMORY_ONLY),
         Option(OrcFileOutputConfig("tmp/DQ/sqlVS")),
-        Seq("batchId")
+        Seq("id")
       )
 
       val joinVirtualSource = JoinVirtualSourceReader.read(joinConfig, parentSources, ReadMode.Batch)
@@ -116,7 +116,7 @@ class VirtualSourceReader extends AnyWordSpec with Matchers {
         SparkJoinType.Left,
         Option(StorageLevel.MEMORY_ONLY),
         Option(OrcFileOutputConfig("tmp/DQ/sqlVS")),
-        Seq("batchId")
+        Seq("id")
       )
 
       val joinVirtualSource = JoinVirtualSourceReader.read(joinConfig, parentSources, ReadMode.Batch)
@@ -139,7 +139,7 @@ class VirtualSourceReader extends AnyWordSpec with Matchers {
         None,
         None,
         None,
-        Seq("batchId", "dttm")
+        Seq("key", "name")
       )
 
       val filterVirtualSource = FilterVirtualSourceReader.read(filterConfig, parentSources, ReadMode.Batch)
@@ -168,7 +168,7 @@ class VirtualSourceReader extends AnyWordSpec with Matchers {
         None,
         None,
         None,
-        Seq("batchId", "dttm")
+        Seq("key", "name")
       )
 
       val filterVirtualSource = FilterVirtualSourceReader.read(filterConfig, parentSources, ReadMode.Batch)

--- a/docs/en/01-application-setup/03-ResultsStorage.md
+++ b/docs/en/01-application-setup/03-ResultsStorage.md
@@ -101,6 +101,33 @@ only one set of results per Data Quality job and given reference date.
 | reference_date    | TIMESTAMP   | NOT NULL   |
 | execution_date    | TIMESTAMP   | NOT NULL   |
 
+
+### Metric Error Results Schema
+
+* Primary key: `(job_id, error_hash, reference_date)`;
+* `source_id` is a JSON string;
+* `source_key_fields` is a JSON string;
+* `metric_columns` is a JSON string;
+* `row_data` is a JSON string.
+* `errorHash` is a MD5 hash string computed from values of columns `metric_id`, `status`, `message` and `row_data`
+
+> **NOTE** Error hash is computed with use of raw value of `row_data` field even if it is encrypted later.
+
+| Column Name       | Column Type | Constraint |
+|-------------------|-------------|------------|
+| job_id            | TEXT        | NOT NULL   |
+| metric_id         | TEXT        | NOT NULL   |
+| source_id         | TEXT        |            |
+| source_key_fields | TEXT        |            |
+| metric_columns    | TEXT        |            |
+| status            | TEXT        | NOT NULL   |
+| message           | TEXT        | NOT NULL   |
+| row_data          | TEXT        | NOT NULL   |
+| error_hash        | TEXT        | NOT NULL   |
+| reference_date    | TIMESTAMP   | NOT NULL   |
+| execution_date    | TIMESTAMP   | NOT NULL   |
+
+
 ### Load Checks Results Schema
 
 * Primary key: `(job_id, check_id, reference_date)`;
@@ -208,6 +235,26 @@ COMMENT 'Data Quality Composed Metrics Results'
 PARTITIONED BY (job_id STRING)
 STORED AS PARQUET
 LOCATION '${schema_dir}/results_metric_composed';
+
+DROP TABLE IF EXISTS ${schema_name}.results_metric_error;
+CREATE EXTERNAL TABLE ${schema_name}.results_metric_error
+(
+    job_id            STRING COMMENT '',
+    metric_id         STRING COMMENT '',
+    source_id         STRING COMMENT '',
+    source_key_fields STRING COMMENT '',
+    metric_columns    STRING COMMENT '',
+    status            STRING COMMENT '',
+    message           STRING COMMENT '',
+    row_data          STRING COMMENT '',
+    error_hash        STRING COMMENT '',
+    reference_date    TIMESTAMP COMMENT '',
+    execution_date    TIMESTAMP COMMENT '',
+)
+COMMENT 'Data Quality Metrics Error Results'
+PARTITIONED BY (job_id STRING)
+STORED AS PARQUET
+LOCATION '${schema_dir}/results_metric_error';
 
 DROP TABLE IF EXISTS ${schema_name}.results_check_load;
 CREATE EXTERNAL TABLE ${schema_name}.results_check_load


### PR DESCRIPTION
- added migration scripts to create new table for storing metric errors.
- added new enabler in storage configuration to control whether metric errors need to be saved in DQ Storage.
- added new enabler in encryption configuration to control whether data excerpts in metric errors should be encrypted.
- modified class storing metric errors and created its Slick table representation. Added error hash field that is used as part of unique key to deduplicate error records. Error hash is and MD5 hash string that is always computed using raw data excerpts even if it is encrypted later.
- added deduplication of finalized metric errors by their unique constraint in order to avoid sending repeating data.
- modified encryptor to make it faster (do not re-generate AES key and initial IV vector for every encryption attempt).
- fixed partition values filter in HiveSourceReader
- added more verbose logs for case when some of the source keyFields are not found within dataframe columns.
- enhances JDBC manager upsert method to avoid stack overflow errors when saving large sequences of results (quite usual case for storing metric errors).
- added Source validation on read: checks that all keyFields are presented in datafarame. 
- refactored application settings logging.
- added implicit class to convert Option instances to Result instances.
- documentation is updated to reflect the changes.