### PR TITLE
fix: implement custom Spark collection accumulator to limit total number of collected errors

### DIFF
--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/connections/jdbc/JdbcConnection.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/connections/jdbc/JdbcConnection.scala
@@ -74,7 +74,7 @@ abstract class JdbcConnection[T <: JdbcConnectionConfig] extends DQConnection {
         spark.read.jdbc(connectionUrl, table, props)
       case (None, Some(q)) => if (settings.allowSqlQueries) {
           props.put("url", connectionUrl)
-          props.put("dbtable", s"($q) ${sourceConfig.id.value}")
+          props.put("dbtable", s"($q) t")
           spark.read.format("jdbc").options(props.asScala).load()
         } else throw new UnsupportedOperationException(
           "FORBIDDEN: Can't load table source with query due to usage of arbitrary SQL queries is not allowed. " + 

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/ErrorCollection.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/ErrorCollection.scala
@@ -1,6 +1,10 @@
 package ru.raiffeisen.checkita.core.metrics
 
+import org.apache.spark.util.AccumulatorV2
 import ru.raiffeisen.checkita.core.CalculatorStatus
+
+import java.util
+import java.util.ArrayList
 
 
 object ErrorCollection {
@@ -45,4 +49,81 @@ object ErrorCollection {
                                 metricStatues: Seq[MetricStatus],
                                 rowData: Seq[String]
                               )
+
+
+  /**
+   * Custom Spark accumulator used to collect metric errors.
+   * The main idea of this accumulator is to limit maximum number of elements that are collected.
+   *
+   * @param limit Maximum number of elements to be collected.
+   *              If limit is non-positive (<= 0) then number of collected elements is not limited.
+   * @tparam T Type of element
+   *
+   * @note Implementation of this accumulator is similar to built-in Spark CollectionAccumulator
+   *       with additional logic added to limit number of collected elements.
+   */
+  class LimitedCollectionAccumulator[T](limit: Int) extends AccumulatorV2[T, java.util.List[T]] {
+    private var _list: java.util.List[T] = _
+
+    private def getOrCreate: util.List[T] = {
+      _list = Option(_list).getOrElse(new java.util.ArrayList[T]())
+      _list
+    }
+
+    /**
+     * Returns false if this accumulator instance has any values in it.
+     */
+    override def isZero: Boolean = this.synchronized(getOrCreate.isEmpty)
+
+    override def copyAndReset(): LimitedCollectionAccumulator[T] = new LimitedCollectionAccumulator[T](limit)
+
+    override def copy(): LimitedCollectionAccumulator[T] = {
+      val newAcc = new LimitedCollectionAccumulator[T](limit)
+      this.synchronized {
+        newAcc.getOrCreate.addAll(getOrCreate)
+      }
+      newAcc
+    }
+
+    override def reset(): Unit = this.synchronized {
+      _list = null
+    }
+
+    override def add(v: T): Unit = this.synchronized {
+      if (limit <= 0 || getOrCreate.size() < limit) getOrCreate.add(v)
+      else ()
+    }
+
+    /**
+     * Merge list of this accumulator with other list
+     * and ensure that resultant list contains no more
+     * that `limit` number of elements.
+     * @param other Other list to merge with current one.
+     */
+    private def mergeListWithLimit(other: java.util.List[T]): Unit = {
+      val maxToAdd = limit - getOrCreate.size()
+      if (other.size() <= maxToAdd) getOrCreate.addAll(other)
+      else getOrCreate.addAll(other.subList(0, maxToAdd))
+    }
+
+    /**
+     * Merges this accumulator instance with another one and ensure that
+     * maximum number of collected elements is less than or equal to `limit`.
+     * @param other Other accumulator instance to be merged.
+     * @note If `limit` is non-positive (<= 0) then number of elements to be collected is not limited.
+     */
+    override def merge(other: AccumulatorV2[T, java.util.List[T]]): Unit = other match {
+      case o: LimitedCollectionAccumulator[T] => this.synchronized {
+        if (limit <= 0) getOrCreate.addAll(o.value)
+        else if (getOrCreate.size() < limit) mergeListWithLimit(o.value)
+        else ()
+      }
+      case _ => throw new UnsupportedOperationException(
+        s"Cannot merge ${this.getClass.getName} with ${other.getClass.getName}")
+    }
+
+    override def value: java.util.List[T] = this.synchronized {
+      java.util.Collections.unmodifiableList(new util.ArrayList[T](getOrCreate))
+    }
+  }
 }

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/ErrorCollection.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/ErrorCollection.scala
@@ -3,9 +3,6 @@ package ru.raiffeisen.checkita.core.metrics
 import org.apache.spark.util.AccumulatorV2
 import ru.raiffeisen.checkita.core.CalculatorStatus
 
-import java.util
-import java.util.ArrayList
-
 
 object ErrorCollection {
 
@@ -65,7 +62,7 @@ object ErrorCollection {
   class LimitedCollectionAccumulator[T](limit: Int) extends AccumulatorV2[T, java.util.List[T]] {
     private var _list: java.util.List[T] = _
 
-    private def getOrCreate: util.List[T] = {
+    private def getOrCreate: java.util.List[T] = {
       _list = Option(_list).getOrElse(new java.util.ArrayList[T]())
       _list
     }
@@ -123,7 +120,7 @@ object ErrorCollection {
     }
 
     override def value: java.util.List[T] = this.synchronized {
-      java.util.Collections.unmodifiableList(new util.ArrayList[T](getOrCreate))
+      java.util.Collections.unmodifiableList(new java.util.ArrayList[T](getOrCreate))
     }
   }
 }


### PR DESCRIPTION
- LimitedCollectionAccumulator is implemented in the similar way as Spark built-in CollectionAccumulator but with logic added to limit maximum number of collected elements. This will allow to limit total number of collected metric errors.
- additionally change JDBC query table properties to remove source ID from table identifier. Reason: source IDs are always a valid Spark Table identifiers. But in some case they might not meet requirements to be valid JDBC query table identifier. Therefore, we'll just use `t` as table identifier for JDBC query.