### PR TITLE
feat: added functionality to reverse error collection logic for regular metrics with conditional criteria

### DIFF
--- a/checkita-core/src/main/resources/version-info.properties
+++ b/checkita-core/src/main/resources/version-info.properties
@@ -1,2 +1,2 @@
 app-version = 1.4.2
-config-api-version = 1.3
+config-api-version = 1.4

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Metrics.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Metrics.scala
@@ -9,22 +9,25 @@ import ru.raiffeisen.checkita.core.metrics.regular.BasicNumericMetrics._
 import ru.raiffeisen.checkita.core.metrics.regular.BasicStringMetrics._
 import ru.raiffeisen.checkita.core.metrics.regular.FileMetrics._
 import ru.raiffeisen.checkita.core.metrics.regular.MultiColumnMetrics._
-import ru.raiffeisen.checkita.core.metrics.{ComposedMetric, MetricCalculator, MetricName, RegularMetric}
+import ru.raiffeisen.checkita.core.metrics._
 import ru.raiffeisen.checkita.utils.Common.{getFieldsMap, jsonFormats}
 
 
 object Metrics {
 
-  /** Base class for all metrics configurations. All metrics are described as DQ entities.
-    */
+  /**
+   * Base class for all metrics configurations. All metrics are described as DQ entities.
+   */
   sealed abstract class MetricConfig extends JobConfigEntity {
     val metricId: String = id.value // actual ID value after validation.
   }
 
-  /** Base class for all regular metric configurations (except row count metric). All regular metrics must have a
-    * reference to source ID over which the metric is being calculated. In addition, column metrics must have non-empty
-    * sequence of columns over which the metric is being calculated.
-    */
+  /**
+   * Base class for all regular metric configurations (except row count metric). All regular metrics must have a
+   * reference to source ID over which the metric is being calculated. In addition, column metrics must have non-empty
+   * sequence of columns over which the metric is being calculated.
+   * Metric error collection logic might be reversed provided with corresponding boolean flag set to `true`.
+   */
   sealed abstract class RegularMetricConfig extends MetricConfig with RegularMetric {
     val source: NonEmptyString
 
@@ -67,16 +70,12 @@ object Metrics {
   }
 
   /** Composed metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param formula
-    *   Formula to calculate composed metric
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param formula     Formula to calculate composed metric
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class ComposedMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -89,16 +88,12 @@ object Metrics {
   }
 
   /** Row count metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class RowCountMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -112,18 +107,13 @@ object Metrics {
   }
 
   /** Duplicate values column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class DuplicateValuesMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -137,18 +127,13 @@ object Metrics {
   }
 
   /** Distinct values column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class DistinctValuesMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -162,20 +147,14 @@ object Metrics {
   }
 
   /** Approximate distinct values column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class ApproxDistinctValuesMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -191,99 +170,85 @@ object Metrics {
   }
 
   /** Null values column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   *                    When reversed is set to `true` then any non-null values are considered as metric failure.
+   *                    Otherwise, null values are collected as metric failure.
+   */
   final case class NullValuesMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = true
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName                 = MetricName.NullValues
     val paramString: Option[String]            = None
-    def initMetricCalculator: MetricCalculator = new NullValuesMetricCalculator()
+    def initMetricCalculator: ReversibleMetricCalculator = new NullValuesMetricCalculator(reversed)
   }
 
   /** Empty values column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class EmptyValuesMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = true
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName                 = MetricName.EmptyValues
     val paramString: Option[String]            = None
-    def initMetricCalculator: MetricCalculator = new EmptyStringValuesMetricCalculator()
+    def initMetricCalculator: ReversibleMetricCalculator = new EmptyStringValuesMetricCalculator(reversed)
   }
 
   /** Completeness column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class CompletenessMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: CompletenessParams = CompletenessParams(),
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = true
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.Completeness
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new CompletenessMetricCalculator(params.includeEmptyStrings)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new CompletenessMetricCalculator(params.includeEmptyStrings, reversed)
   }
 
   /** Sequence completeness column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class SequenceCompletenessMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -299,20 +264,14 @@ object Metrics {
   }
 
   /** Sequence completeness column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class ApproxSequenceCompletenessMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -328,18 +287,13 @@ object Metrics {
   }
 
   /** Min string column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class MinStringMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -353,18 +307,13 @@ object Metrics {
   }
 
   /** Max string column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class MaxStringMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -378,18 +327,13 @@ object Metrics {
   }
 
   /** Average string column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class AvgStringMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -403,251 +347,217 @@ object Metrics {
   }
 
   /** String length column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class StringLengthMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: StringLengthParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.StringLength
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new StringLengthValuesMetricCalculator(params.length.value, params.compareRule.toString.toLowerCase)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new StringLengthValuesMetricCalculator(params.length.value, params.compareRule.toString.toLowerCase, reversed)
   }
 
   /** String in domain column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class StringInDomainMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: StringDomainParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.StringInDomain
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new StringInDomainValuesMetricCalculator(params.domain.value.toSet)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new StringInDomainValuesMetricCalculator(params.domain.value.toSet, reversed)
   }
 
   /** String out domain column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class StringOutDomainMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: StringDomainParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.StringOutDomain
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new StringOutDomainValuesMetricCalculator(params.domain.value.toSet)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new StringOutDomainValuesMetricCalculator(params.domain.value.toSet, reversed)
   }
 
   /** String values column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class StringValuesMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: StringValuesParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.StringValues
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new StringValuesMetricCalculator(params.compareValue.value)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new StringValuesMetricCalculator(params.compareValue.value, reversed)
   }
 
   /** Regex match column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class RegexMatchMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: RegexParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName                 = MetricName.RegexMatch
     val paramString: Option[String]            = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator = new RegexMatchMetricCalculator(params.regex.value)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new RegexMatchMetricCalculator(params.regex.value, reversed)
   }
 
   /** Regex mismatch column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class RegexMismatchMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: RegexParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName                 = MetricName.RegexMismatch
     val paramString: Option[String]            = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator = new RegexMismatchMetricCalculator(params.regex.value)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new RegexMismatchMetricCalculator(params.regex.value, reversed)
   }
 
   /** Formatted date column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class FormattedDateMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: FormattedDateParams = FormattedDateParams(),
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.FormattedDate
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new DateFormattedValuesMetricCalculator(params.dateFormat.pattern)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new DateFormattedValuesMetricCalculator(params.dateFormat.pattern, reversed)
   }
 
   /** Formatted number column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class FormattedNumberMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: FormattedNumberParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.FormattedNumber
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator = new NumberFormattedValuesMetricCalculator(
+    def initMetricCalculator: ReversibleMetricCalculator = new NumberFormattedValuesMetricCalculator(
       params.precision.value,
       params.scale.value,
-      params.compareRule.toString.toLowerCase
+      params.compareRule.toString.toLowerCase,
+      reversed
     )
   }
 
   /** Min number column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class MinNumberMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -661,18 +571,13 @@ object Metrics {
   }
 
   /** Max number column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class MaxNumberMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -686,18 +591,13 @@ object Metrics {
   }
 
   /** Sum number column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class SumNumberMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -711,18 +611,13 @@ object Metrics {
   }
 
   /** Average number column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class AvgNumberMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -736,18 +631,13 @@ object Metrics {
   }
 
   /** Standard deviation number column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class StdNumberMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -761,248 +651,214 @@ object Metrics {
   }
 
   /** Casted number column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class CastedNumberMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName                 = MetricName.CastedNumber
     val paramString: Option[String]            = None
-    def initMetricCalculator: MetricCalculator = new NumberCastValuesMetricCalculator()
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new NumberCastValuesMetricCalculator(reversed)
   }
 
   /** Number in domain column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class NumberInDomainMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: NumberDomainParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.NumberInDomain
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new NumberInDomainValuesMetricCalculator(params.domain.value.toSet)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new NumberInDomainValuesMetricCalculator(params.domain.value.toSet, reversed)
   }
 
   /** Number out domain column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class NumberOutDomainMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: NumberDomainParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.NumberOutDomain
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new NumberOutDomainValuesMetricCalculator(params.domain.value.toSet)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new NumberOutDomainValuesMetricCalculator(params.domain.value.toSet, reversed)
   }
 
   /** Number less than column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class NumberLessThanMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: NumberCompareParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.NumberLessThan
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new NumberLessThanMetricCalculator(params.compareValue, params.includeBound)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new NumberLessThanMetricCalculator(params.compareValue, params.includeBound, reversed)
   }
 
   /** Number greater than column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class NumberGreaterThanMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: NumberCompareParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.NumberGreaterThan
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new NumberGreaterThanMetricCalculator(params.compareValue, params.includeBound)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new NumberGreaterThanMetricCalculator(params.compareValue, params.includeBound, reversed)
   }
 
   /** Number between column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class NumberBetweenMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: NumberIntervalParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.NumberBetween
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new NumberBetweenMetricCalculator(params.lowerCompareValue, params.upperCompareValue, params.includeBound)
+    def initMetricCalculator: ReversibleMetricCalculator = new NumberBetweenMetricCalculator(
+      params.lowerCompareValue, params.upperCompareValue, params.includeBound, reversed
+    )
   }
 
   /** Number not between column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class NumberNotBetweenMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: NumberIntervalParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.NumberNotBetween
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new NumberNotBetweenMetricCalculator(params.lowerCompareValue, params.upperCompareValue, params.includeBound)
+    def initMetricCalculator: ReversibleMetricCalculator = new NumberNotBetweenMetricCalculator(
+      params.lowerCompareValue, params.upperCompareValue, params.includeBound, reversed
+    )
   }
 
   /** Number values column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class NumberValuesMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: NonEmptyStringSeq,
       params: NumberValuesParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends AnyColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends AnyColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.NumberValues
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new NumberValuesMetricCalculator(params.compareValue)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new NumberValuesMetricCalculator(params.compareValue, reversed)
   }
 
   /** TDigest Median value column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class MedianValueMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -1018,20 +874,14 @@ object Metrics {
   }
 
   /** TDigest First quantile column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class FirstQuantileMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -1047,20 +897,14 @@ object Metrics {
   }
 
   /** TDigest Third quantile column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class ThirdQuantileMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -1076,20 +920,14 @@ object Metrics {
   }
 
   /** TDigest Get quantile column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class GetQuantileMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -1105,20 +943,14 @@ object Metrics {
   }
 
   /** TDigest Get percentile column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class GetPercentileMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -1134,101 +966,85 @@ object Metrics {
   }
 
   /** Column equality metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class ColumnEqMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: MultiElemStringSeq,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends MultiColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends MultiColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName                 = MetricName.ColumnEq
     val paramString: Option[String]            = None
-    def initMetricCalculator: MetricCalculator = new EqualStringColumnsMetricCalculator()
+    def initMetricCalculator: ReversibleMetricCalculator = new EqualStringColumnsMetricCalculator(reversed)
   }
 
   /** Day distance column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class DayDistanceMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: DoubleElemStringSeq,
       params: DayDistanceParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends DoubleColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends DoubleColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.DayDistance
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new DayDistanceMetricCalculator(params.dateFormat.pattern, params.threshold.value)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new DayDistanceMetricCalculator(params.dateFormat.pattern, params.threshold.value, reversed)
   }
 
   /** Levenshtein distance column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   * @param reversed    Boolean flag indicating whether error collection logic should be reversed for this metric
+   */
   final case class LevenshteinDistanceMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
       source: NonEmptyString,
       columns: DoubleElemStringSeq,
       params: LevenshteinDistanceParams,
-      metadata: Seq[SparkParam] = Seq.empty
-  ) extends DoubleColumnRegularMetricConfig {
+      metadata: Seq[SparkParam] = Seq.empty,
+      reversed: Boolean = false
+  ) extends DoubleColumnRegularMetricConfig with ReversibleMetric {
     val metricName: MetricName      = MetricName.LevenshteinDistance
     val paramString: Option[String] = Some(write(getFieldsMap(params)))
-    def initMetricCalculator: MetricCalculator =
-      new LevenshteinDistanceMetricCalculator(params.threshold, params.normalize)
+    def initMetricCalculator: ReversibleMetricCalculator =
+      new LevenshteinDistanceMetricCalculator(params.threshold, params.normalize, reversed)
   }
 
   /** Co-moment column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class CoMomentMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -1242,18 +1058,13 @@ object Metrics {
   }
 
   /** Covariance column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class CovarianceMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -1267,18 +1078,13 @@ object Metrics {
   }
 
   /** Covariance Bessel column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class CovarianceBesselMetricConfig(
       id: ID,
       description: Option[NonEmptyString],
@@ -1292,20 +1098,14 @@ object Metrics {
   }
 
   /** TopN column metric configuration
-    *
-    * @param id
-    *   Metric ID
-    * @param description
-    *   Metric description
-    * @param source
-    *   Source ID over which metric is being calculated
-    * @param columns
-    *   Sequence of columns which are used for metric calculation
-    * @param params
-    *   Metric parameters
-    * @param metadata
-    *   List of metadata parameters specific to this metric
-    */
+   *
+   * @param id          Metric ID
+   * @param description Metric description
+   * @param source      Source ID over which metric is being calculated
+   * @param columns     Sequence of columns which are used for metric calculation
+   * @param params      Metric parameters
+   * @param metadata    List of metadata parameters specific to this metric
+   */
   final case class TopNMetricConfig(
       id: ID,
       description: Option[NonEmptyString],

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/context/DQStreamWindowJob.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/context/DQStreamWindowJob.scala
@@ -42,6 +42,8 @@ import scala.util.Try
  * @param jobId           Implicit job ID
  * @param spark           Implicit spark session object
  * @param fs              Implicit hadoop file system object
+ * @param dumpSize        Implicit value of maximum number of metric failures (or errors) to be collected (per metric).
+ *                        Used to prevent OOM errors.
  */
 final case class DQStreamWindowJob(jobConfig: JobConfig,
                                    settings: AppSettings,
@@ -57,7 +59,8 @@ final case class DQStreamWindowJob(jobConfig: JobConfig,
                                   )(implicit val jobId: String,
                                     val spark: SparkSession,
                                     val fs: FileSystem,
-                                    val buffer: ProcessorBuffer) extends Thread with DQJob {
+                                    val buffer: ProcessorBuffer,
+                                    val dumpSize: Int) extends Thread with DQJob {
 
   private implicit val streamConfig: StreamConfig = settings.streamConfig
   private val processedSources: Map[String, Source] = sources.filter(src => metricsBySources.contains(src.id))

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/ErrorCollection.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/ErrorCollection.scala
@@ -1,8 +1,6 @@
 package ru.raiffeisen.checkita.core.metrics
 
-import org.apache.spark.util.AccumulatorV2
 import ru.raiffeisen.checkita.core.CalculatorStatus
-
 
 object ErrorCollection {
 
@@ -46,81 +44,4 @@ object ErrorCollection {
                                 metricStatues: Seq[MetricStatus],
                                 rowData: Seq[String]
                               )
-
-
-  /**
-   * Custom Spark accumulator used to collect metric errors.
-   * The main idea of this accumulator is to limit maximum number of elements that are collected.
-   *
-   * @param limit Maximum number of elements to be collected.
-   *              If limit is non-positive (<= 0) then number of collected elements is not limited.
-   * @tparam T Type of element
-   *
-   * @note Implementation of this accumulator is similar to built-in Spark CollectionAccumulator
-   *       with additional logic added to limit number of collected elements.
-   */
-  class LimitedCollectionAccumulator[T](limit: Int) extends AccumulatorV2[T, java.util.List[T]] {
-    private var _list: java.util.List[T] = _
-
-    private def getOrCreate: java.util.List[T] = {
-      _list = Option(_list).getOrElse(new java.util.ArrayList[T]())
-      _list
-    }
-
-    /**
-     * Returns false if this accumulator instance has any values in it.
-     */
-    override def isZero: Boolean = this.synchronized(getOrCreate.isEmpty)
-
-    override def copyAndReset(): LimitedCollectionAccumulator[T] = new LimitedCollectionAccumulator[T](limit)
-
-    override def copy(): LimitedCollectionAccumulator[T] = {
-      val newAcc = new LimitedCollectionAccumulator[T](limit)
-      this.synchronized {
-        newAcc.getOrCreate.addAll(getOrCreate)
-      }
-      newAcc
-    }
-
-    override def reset(): Unit = this.synchronized {
-      _list = null
-    }
-
-    override def add(v: T): Unit = this.synchronized {
-      if (limit <= 0 || getOrCreate.size() < limit) getOrCreate.add(v)
-      else ()
-    }
-
-    /**
-     * Merge list of this accumulator with other list
-     * and ensure that resultant list contains no more
-     * that `limit` number of elements.
-     * @param other Other list to merge with current one.
-     */
-    private def mergeListWithLimit(other: java.util.List[T]): Unit = {
-      val maxToAdd = limit - getOrCreate.size()
-      if (other.size() <= maxToAdd) getOrCreate.addAll(other)
-      else getOrCreate.addAll(other.subList(0, maxToAdd))
-    }
-
-    /**
-     * Merges this accumulator instance with another one and ensure that
-     * maximum number of collected elements is less than or equal to `limit`.
-     * @param other Other accumulator instance to be merged.
-     * @note If `limit` is non-positive (<= 0) then number of elements to be collected is not limited.
-     */
-    override def merge(other: AccumulatorV2[T, java.util.List[T]]): Unit = other match {
-      case o: LimitedCollectionAccumulator[T] => this.synchronized {
-        if (limit <= 0) getOrCreate.addAll(o.value)
-        else if (getOrCreate.size() < limit) mergeListWithLimit(o.value)
-        else ()
-      }
-      case _ => throw new UnsupportedOperationException(
-        s"Cannot merge ${this.getClass.getName} with ${other.getClass.getName}")
-    }
-
-    override def value: java.util.List[T] = this.synchronized {
-      java.util.Collections.unmodifiableList(new java.util.ArrayList[T](getOrCreate))
-    }
-  }
 }

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/MetricStreamProcessor.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/MetricStreamProcessor.scala
@@ -186,18 +186,21 @@ object MetricStreamProcessor extends MetricProcessor with Logging {
 
   /**
    * Processes calculator results and accumulated errors once stream window state is finalized.
-   * @param gc Final map of grouped metric calculators for stream window
-   * @param errors Final sequence of metric errors accumulated for stream window
+   *
+   * @param gc          Final map of grouped metric calculators for stream window
+   * @param errors      Final sequence of metric errors accumulated for stream window
    * @param windowStart Window start datetime (string in format 'yyyy-MM-dd HH:mm:ss')
-   * @param streamId Id of the stream source for which results are processed.
-   * @param streamKeys Stream source key fields.
+   * @param streamId    Id of the stream source for which results are processed.
+   * @param streamKeys  Stream source key fields.
+   * @param dumpSize    Implicit value of maximum number of metric failures (or errors) to be collected (per metric).
+   *                    Used to prevent OOM errors.
    * @return Map of metricId to a sequence of metric results for this metricId (some metrics yield multiple results).
    */
   def processWindowResults(gc: GroupedCalculators,
                            errors: Seq[AccumulatedErrors],
                            windowStart: String,
                            streamId: String,
-                           streamKeys: Seq[String]): Result[MetricResults] = Try {
+                           streamKeys: Seq[String])(implicit dumpSize: Int): Result[MetricResults] = Try {
     buildResults(gc, processMetricErrors(errors), streamId, streamKeys)
   }.toResult(preMsg = s"Unable to process metrics for stream $streamId at window $windowStart due to following error:")
 }

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/ReversibleCalculator.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/ReversibleCalculator.scala
@@ -1,0 +1,40 @@
+package ru.raiffeisen.checkita.core.metrics
+
+import ru.raiffeisen.checkita.core.CalculatorStatus
+
+import scala.util.{Failure, Success, Try}
+
+/**
+ * Trait to be mixed in to metric calculator to support reversal of error collection logic.
+ *
+ *   - Reversible metric calculators can collect metric errors either in direct or in reversed mode depending
+ *     on provided boolean flag.
+ */
+trait ReversibleCalculator { this: MetricCalculator =>
+  protected val reversed: Boolean
+
+  /**
+   * Increment metric calculator with REVERSED error collection logic. May throw an exception.
+   *
+   * @param values values to process
+   * @return updated calculator or throws an exception
+   */
+  protected def tryToIncrementReversed(values: Seq[Any]): MetricCalculator
+
+  /**
+   * Safely updates metric calculator with respect to
+   * specified error collection logic (direct or reversed).
+   *
+   * @param values values to process
+   * @return updated calculator
+   */
+  override def increment(values: Seq[Any]): MetricCalculator = {
+    val incrementFunc: Seq[Any] => MetricCalculator =
+      v => if (reversed) tryToIncrementReversed(v) else tryToIncrement(v)
+
+    Try(incrementFunc(values)) match {
+      case Success(calc) => calc
+      case Failure(e) => copyWithError(CalculatorStatus.Error, e.getMessage)
+    }
+  }
+}

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/ReversibleMetric.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/ReversibleMetric.scala
@@ -1,0 +1,16 @@
+package ru.raiffeisen.checkita.core.metrics
+
+/**
+ * Trait to be mixed in to reversible metric definitions (configurations).
+ *
+ *   - Reversible metrics must defined boolean flag indicating whether error collection
+ *     logic for metric is direct or reversed.
+ *
+ *   - Initialization of metric calculator must return instance of reversible metric calculator
+ *     (one that supports error collection logic reversal).
+ */
+trait ReversibleMetric { this: RegularMetric =>
+  type ReversibleMetricCalculator = MetricCalculator with ReversibleCalculator
+  val reversed: Boolean
+  override def initMetricCalculator: ReversibleMetricCalculator
+}

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/regular/AlgebirdMetrics.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/metrics/regular/AlgebirdMetrics.scala
@@ -55,7 +55,7 @@ object AlgebirdMetrics {
           )
         case None => copyWithError(
           CalculatorStatus.Failure,
-          "Provided value cannot be casted to string"
+          "Provided value cannot be cast to string"
         )
       }
     }
@@ -131,7 +131,7 @@ object AlgebirdMetrics {
           )
         case None => copyWithError(
           CalculatorStatus.Failure,
-          "Provided value cannot be casted to string"
+          "Provided value cannot be cast to string"
         )
       }
     }
@@ -199,7 +199,7 @@ object AlgebirdMetrics {
           )
         case None => copyWithError(
           CalculatorStatus.Failure,
-          "Provided value cannot be casted to string"
+          "Provided value cannot be cast to string"
         )
       }
     }

--- a/checkita-core/src/test/scala/ru/raiffeisen/checkita/core/metrics/regular/BasicStringMetricsSpec.scala
+++ b/checkita-core/src/test/scala/ru/raiffeisen/checkita/core/metrics/regular/BasicStringMetricsSpec.scala
@@ -125,44 +125,67 @@ class BasicStringMetricsSpec extends AnyWordSpec with Matchers {
     )
     val results = Seq(1, 4, 3, 4)
     val failCounts = Seq(11, 8, 9, 8)
+    val failCountsRev = Seq(1, 4, 3, 4)
 
     "return correct metric value for single column sequence" in {
       val values = (testSingleColSeq, regexList, results).zipped.toList
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new RegexMatchMetricCalculator(t._2))(
-          (m, v) => m.increment(Seq(v))).result()(MetricName.RegexMatch.entryName)._1,
-        t._3
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new RegexMatchMetricCalculator(t._2, reversed))(
+            (m, v) => m.increment(Seq(v))).result()(MetricName.RegexMatch.entryName)._1,
+          t._3
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for single column sequence" in {
+    "return correct fail counts for single column sequence [direct error collection]" in {
       val values = (testSingleColSeq, regexList, failCounts).zipped.toList
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new RegexMatchMetricCalculator(t._2))((m, v) => m.increment(Seq(v))),
+        t._1.foldLeft[MetricCalculator](new RegexMatchMetricCalculator(t._2, false))((m, v) => m.increment(Seq(v))),
+        t._3
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for single column sequence [reversed error collection]" in {
+      val values = (testSingleColSeq, regexList, failCountsRev).zipped.toList
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new RegexMatchMetricCalculator(t._2, true))((m, v) => m.increment(Seq(v))),
         t._3
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return correct metric value for multi column sequence" in {
       val values = (testMultiColSeq, regexList, results).zipped.toList
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new RegexMatchMetricCalculator(t._2))(
-          (m, v) => m.increment(v)).result()(MetricName.RegexMatch.entryName)._1,
-        t._3
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new RegexMatchMetricCalculator(t._2, reversed))(
+            (m, v) => m.increment(v)).result()(MetricName.RegexMatch.entryName)._1,
+          t._3
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for multi column sequence" in {
+    "return correct fail counts for multi column sequence [direct error collection]" in {
       val values = (testMultiColSeq, regexList, failCounts).zipped.toList
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new RegexMatchMetricCalculator(t._2))((m, v) => m.increment(v)),
+        t._1.foldLeft[MetricCalculator](new RegexMatchMetricCalculator(t._2, false))((m, v) => m.increment(v)),
+        t._3
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for multi column sequence [reversed error collection]" in {
+      val values = (testMultiColSeq, regexList, failCountsRev).zipped.toList
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new RegexMatchMetricCalculator(t._2, true))((m, v) => m.increment(v)),
         t._3
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return zero when applied to empty sequence" in {
       val values = Seq.empty
-      val metricResult = values.foldLeft[MetricCalculator](new RegexMatchMetricCalculator(regexList.head))(
+      val metricResult = values.foldLeft[MetricCalculator](new RegexMatchMetricCalculator(regexList.head, false))(
         (m, v) => m.increment(v)
       )
       metricResult.result()(MetricName.RegexMatch.entryName)._1 shouldEqual 0
@@ -178,44 +201,67 @@ class BasicStringMetricsSpec extends AnyWordSpec with Matchers {
     )
     val results = Seq(11, 8, 9, 8)
     val failCounts = Seq(1, 4, 3, 4)
+    val failCountsRev = Seq(11, 8, 9, 8)
 
     "return correct metric value for single column sequence" in {
       val values = (testSingleColSeq, regexList, results).zipped.toList
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new RegexMismatchMetricCalculator(t._2))(
-          (m, v) => m.increment(Seq(v))).result()(MetricName.RegexMismatch.entryName)._1,
-        t._3
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new RegexMismatchMetricCalculator(t._2, reversed))(
+            (m, v) => m.increment(Seq(v))).result()(MetricName.RegexMismatch.entryName)._1,
+          t._3
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for single column sequence" in {
+    "return correct fail counts for single column sequence [direct error collection]" in {
       val values = (testSingleColSeq, regexList, failCounts).zipped.toList
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new RegexMismatchMetricCalculator(t._2))((m, v) => m.increment(Seq(v))),
+        t._1.foldLeft[MetricCalculator](new RegexMismatchMetricCalculator(t._2, false))((m, v) => m.increment(Seq(v))),
+        t._3
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for single column sequence [reversed error collection]" in {
+      val values = (testSingleColSeq, regexList, failCountsRev).zipped.toList
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new RegexMismatchMetricCalculator(t._2, true))((m, v) => m.increment(Seq(v))),
         t._3
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return correct metric value for multi column sequence" in {
       val values = (testMultiColSeq, regexList, results).zipped.toList
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new RegexMismatchMetricCalculator(t._2))(
-          (m, v) => m.increment(v)).result()(MetricName.RegexMismatch.entryName)._1,
-        t._3
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new RegexMismatchMetricCalculator(t._2, reversed))(
+            (m, v) => m.increment(v)).result()(MetricName.RegexMismatch.entryName)._1,
+          t._3
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for multi column sequence" in {
+    "return correct fail counts for multi column sequence [direct error collection]" in {
       val values = (testMultiColSeq, regexList, failCounts).zipped.toList
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new RegexMismatchMetricCalculator(t._2))((m, v) => m.increment(v)),
+        t._1.foldLeft[MetricCalculator](new RegexMismatchMetricCalculator(t._2, false))((m, v) => m.increment(v)),
+        t._3
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for multi column sequence [reversed error collection]" in {
+      val values = (testMultiColSeq, regexList, failCountsRev).zipped.toList
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new RegexMismatchMetricCalculator(t._2, true))((m, v) => m.increment(v)),
         t._3
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return zero when applied to empty sequence" in {
       val values = Seq.empty
-      val metricResult = values.foldLeft[MetricCalculator](new RegexMismatchMetricCalculator(regexList.head))(
+      val metricResult = values.foldLeft[MetricCalculator](new RegexMismatchMetricCalculator(regexList.head, false))(
         (m, v) => m.increment(v)
       )
       metricResult.result()(MetricName.RegexMismatch.entryName)._1 shouldEqual 0
@@ -224,44 +270,68 @@ class BasicStringMetricsSpec extends AnyWordSpec with Matchers {
 
   "NullValuesMetricCalculator" must {
     val results = Seq.fill(4)(3)
+    val failCount = Seq.fill(4)(9)
+    val failCountRev = Seq.fill(4)(3)
 
     "return correct metric value for single column sequence" in {
       val values = nullSingleColSeq zip results
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new NullValuesMetricCalculator())(
-          (m, v) => m.increment(Seq(v))).result()(MetricName.NullValues.entryName)._1,
-        t._2
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new NullValuesMetricCalculator(reversed))(
+            (m, v) => m.increment(Seq(v))).result()(MetricName.NullValues.entryName)._1,
+          t._2
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for single column sequence" in {
-      val values = nullSingleColSeq zip results
+    "return correct fail counts for single column sequence [direct error collection]" in {
+      val values = nullSingleColSeq zip failCount
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new NullValuesMetricCalculator())((m, v) => m.increment(Seq(v))),
+        t._1.foldLeft[MetricCalculator](new NullValuesMetricCalculator(false))((m, v) => m.increment(Seq(v))),
+        t._2
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for single column sequence [reversed error collection]" in {
+      val values = nullSingleColSeq zip failCountRev
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new NullValuesMetricCalculator(true))((m, v) => m.increment(Seq(v))),
         t._2
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return correct metric value for multi column sequence" in {
       val values = nullMultiColSeq zip results
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new NullValuesMetricCalculator())(
-          (m, v) => m.increment(v)).result()(MetricName.NullValues.entryName)._1,
-        t._2
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new NullValuesMetricCalculator(reversed))(
+            (m, v) => m.increment(v)).result()(MetricName.NullValues.entryName)._1,
+          t._2
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for multi column sequence" in {
-      val values = nullMultiColSeq zip results
+    "return correct fail counts for multi column sequence [direct error collection]" in {
+      val values = nullMultiColSeq zip failCount
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new NullValuesMetricCalculator())((m, v) => m.increment(v)),
+        t._1.foldLeft[MetricCalculator](new NullValuesMetricCalculator(false))((m, v) => m.increment(v)),
+        t._2
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for multi column sequence [reversed error collection]" in {
+      val values = nullMultiColSeq zip failCountRev
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new NullValuesMetricCalculator(true))((m, v) => m.increment(v)),
         t._2
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return zero when applied to empty sequence" in {
       val values = Seq.empty
-      val metricResult = values.foldLeft[MetricCalculator](new NullValuesMetricCalculator())(
+      val metricResult = values.foldLeft[MetricCalculator](new NullValuesMetricCalculator(false))(
         (m, v) => m.increment(v)
       )
       metricResult.result()(MetricName.NullValues.entryName)._1 shouldEqual 0
@@ -270,44 +340,68 @@ class BasicStringMetricsSpec extends AnyWordSpec with Matchers {
 
   "EmptyStringValuesMetricCalculator" must {
     val results = Seq.fill(4)(3)
+    val failCount = Seq.fill(4)(9)
+    val failCountRev = Seq.fill(4)(3)
 
     "return correct metric value for single column sequence" in {
       val values = emptySingleColSeq zip results
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new EmptyStringValuesMetricCalculator())(
-          (m, v) => m.increment(Seq(v))).result()(MetricName.EmptyValues.entryName)._1,
-        t._2
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new EmptyStringValuesMetricCalculator(reversed))(
+            (m, v) => m.increment(Seq(v))).result()(MetricName.EmptyValues.entryName)._1,
+          t._2
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for single column sequence" in {
-      val values = emptySingleColSeq zip results
+    "return correct fail counts for single column sequence [direct error collection]" in {
+      val values = emptySingleColSeq zip failCount
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new EmptyStringValuesMetricCalculator())((m, v) => m.increment(Seq(v))),
+        t._1.foldLeft[MetricCalculator](new EmptyStringValuesMetricCalculator(false))((m, v) => m.increment(Seq(v))),
+        t._2
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for single column sequence [reversed error collection]" in {
+      val values = emptySingleColSeq zip failCountRev
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new EmptyStringValuesMetricCalculator(true))((m, v) => m.increment(Seq(v))),
         t._2
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return correct metric value for multi column sequence" in {
       val values = emptyMultiColSeq zip results
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new EmptyStringValuesMetricCalculator())(
-          (m, v) => m.increment(v)).result()(MetricName.EmptyValues.entryName)._1,
-        t._2
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new EmptyStringValuesMetricCalculator(reversed))(
+            (m, v) => m.increment(v)).result()(MetricName.EmptyValues.entryName)._1,
+          t._2
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for multi column sequence" in {
-      val values = emptyMultiColSeq zip results
+    "return correct fail counts for multi column sequence [direct error collection]" in {
+      val values = emptyMultiColSeq zip failCount
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new EmptyStringValuesMetricCalculator())((m, v) => m.increment(v)),
+        t._1.foldLeft[MetricCalculator](new EmptyStringValuesMetricCalculator(false))((m, v) => m.increment(v)),
+        t._2
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for multi column sequence [reversed error collection]" in {
+      val values = emptyMultiColSeq zip failCountRev
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new EmptyStringValuesMetricCalculator(true))((m, v) => m.increment(v)),
         t._2
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return zero when applied to empty sequence" in {
       val values = Seq.empty
-      val metricResult = values.foldLeft[MetricCalculator](new EmptyStringValuesMetricCalculator())(
+      val metricResult = values.foldLeft[MetricCalculator](new EmptyStringValuesMetricCalculator(false))(
         (m, v) => m.increment(v)
       )
       metricResult.result()(MetricName.EmptyValues.entryName)._1 shouldEqual 0
@@ -317,34 +411,86 @@ class BasicStringMetricsSpec extends AnyWordSpec with Matchers {
   "CompletenessMetricCalculator" must {
     val paramList: Seq[Boolean] = Seq(false, false, true)
     val results = Seq(Seq.fill(4)(1.0), Seq.fill(4)(0.75), Seq.fill(4)(0.5))
+    val failCount = Seq(Seq.fill(4)(12), Seq.fill(4)(9), Seq.fill(4)(6))
+    val failCountRev = Seq(Seq.fill(4)(0), Seq.fill(4)(3), Seq.fill(4)(6))
     val allSingleColSeq = Seq(testSingleColSeq, nullSingleColSeq, emptySingleColSeq)
     val allMultiColSeq = Seq(testMultiColSeq, nullMultiColSeq, emptyMultiColSeq)
 
     "return correct metric value for single column sequence" in {
       (allSingleColSeq, paramList, results).zipped.toList.foreach { tt =>
         val values = tt._1 zip tt._3
+        val metricResults = for {
+          reversed <- Seq(false, true)
+          metricResult <- values.map(t => (
+            t._1.foldLeft[MetricCalculator](new CompletenessMetricCalculator(tt._2, reversed))(
+              (m, v) => m.increment(Seq(v))).result()(MetricName.Completeness.entryName)._1,
+            t._2
+          ))
+        } yield metricResult
+        metricResults.foreach(v => v._1 shouldEqual v._2)
+      }
+    }
+    "return correct fail counts for single column sequence [direct error collection]" in {
+      (allSingleColSeq, paramList, failCount).zipped.toList.foreach { tt =>
+        val values = tt._1 zip tt._3
         val metricResults = values.map(t => (
-          t._1.foldLeft[MetricCalculator](new CompletenessMetricCalculator(tt._2))(
-            (m, v) => m.increment(Seq(v))).result()(MetricName.Completeness.entryName)._1,
+          t._1.foldLeft[MetricCalculator](new CompletenessMetricCalculator(tt._2, false))(
+            (m, v) => m.increment(Seq(v))
+          ),
           t._2
         ))
-        metricResults.foreach(v => v._1 shouldEqual v._2)
+        metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+      }
+    }
+    "return correct fail counts for single column sequence [reversed error collection]" in {
+      (allSingleColSeq, paramList, failCountRev).zipped.toList.foreach { tt =>
+        val values = tt._1 zip tt._3
+        val metricResults = values.map(t => (
+          t._1.foldLeft[MetricCalculator](new CompletenessMetricCalculator(tt._2, true))(
+            (m, v) => m.increment(Seq(v))
+          ),
+          t._2
+        ))
+        metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
       }
     }
     "return correct metric value for multi column sequence" in {
       (allMultiColSeq, paramList, results).zipped.toList.foreach { tt =>
         val values = tt._1 zip tt._3
+        val metricResults = for {
+          reversed <- Seq(false, true)
+          metricResult <- values.map(t => (
+            t._1.foldLeft[MetricCalculator](new CompletenessMetricCalculator(tt._2, reversed))(
+              (m, v) => m.increment(v)).result()(MetricName.Completeness.entryName)._1,
+            t._2
+          ))
+        } yield metricResult
+        metricResults.foreach(v => v._1 shouldEqual v._2)
+      }
+    }
+    "return correct fail counts for multi column sequence [direct error collection]" in {
+      (allMultiColSeq, paramList, failCount).zipped.toList.foreach { tt =>
+        val values = tt._1 zip tt._3
         val metricResults = values.map(t => (
-          t._1.foldLeft[MetricCalculator](new CompletenessMetricCalculator(tt._2))(
-            (m, v) => m.increment(v)).result()(MetricName.Completeness.entryName)._1,
+          t._1.foldLeft[MetricCalculator](new CompletenessMetricCalculator(tt._2, false))((m, v) => m.increment(v)),
           t._2
         ))
-        metricResults.foreach(v => v._1 shouldEqual v._2)
+        metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+      }
+    }
+    "return correct fail counts for multi column sequence [reversed error collection]" in {
+      (allMultiColSeq, paramList, failCountRev).zipped.toList.foreach { tt =>
+        val values = tt._1 zip tt._3
+        val metricResults = values.map(t => (
+          t._1.foldLeft[MetricCalculator](new CompletenessMetricCalculator(tt._2, true))((m, v) => m.increment(v)),
+          t._2
+        ))
+        metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
       }
     }
     "return NaN when applied to empty sequence" in {
       val values = Seq.empty
-      val metricResult = values.foldLeft[MetricCalculator](new CompletenessMetricCalculator(paramList.head))(
+      val metricResult = values.foldLeft[MetricCalculator](new CompletenessMetricCalculator(paramList.head, false))(
         (m, v) => m.increment(v)
       )
       metricResult.result()(MetricName.Completeness.entryName)._1.isNaN shouldEqual true
@@ -442,12 +588,12 @@ class BasicStringMetricsSpec extends AnyWordSpec with Matchers {
   }
 
   "DateFormattedValuesMetricCalculator" must {
-    // (params, metric_result, failure_count)
-    val paramsWithResults: Seq[(String, Int, Int)] = Seq(
-      ("yyyy-MM-dd", 2, 10),
-      ("EEE, MMM dd, yyyy", 1, 11),
-      ("yyyy-MM-dd'T'HH:mm:ss.SSSZ", 1, 11),
-      ("h:mm a", 2, 10)
+    // (params, metric_result, failure_count, reversed_failure_count)
+    val paramsWithResults: Seq[(String, Int, Int, Int)] = Seq(
+      ("yyyy-MM-dd", 2, 10, 2),
+      ("EEE, MMM dd, yyyy", 1, 11, 1),
+      ("yyyy-MM-dd'T'HH:mm:ss.SSSZ", 1, 11, 1),
+      ("h:mm a", 2, 10, 2)
     )
     val valuesSingleCol = Seq(
       "Gpi2C7", "DgXDiA", "2022-03-43", "2001-07-04T12:08:56.235-0700",
@@ -455,41 +601,63 @@ class BasicStringMetricsSpec extends AnyWordSpec with Matchers {
     val valuesMultiCol = (0 to 3).map(c => (0 to 2).map(r => c*3 + r)).map(_.map(valuesSingleCol(_)))
 
     "return correct metric value for single column sequence" in {
-      val metricResults = paramsWithResults.map(t => (
-        valuesSingleCol.foldLeft[MetricCalculator](new DateFormattedValuesMetricCalculator(t._1))(
-          (m, v) => m.increment(Seq(v))).result()(MetricName.FormattedDate.entryName)._1,
-        t._2
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- paramsWithResults.map(t => (
+          valuesSingleCol.foldLeft[MetricCalculator](new DateFormattedValuesMetricCalculator(t._1, reversed))(
+            (m, v) => m.increment(Seq(v))).result()(MetricName.FormattedDate.entryName)._1,
+          t._2
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct failure counts for single column sequence" in {
+    "return correct failure counts for single column sequence [direct error collection]" in {
       val metricResults = paramsWithResults.map(t => (
-        valuesSingleCol.foldLeft[MetricCalculator](new DateFormattedValuesMetricCalculator(t._1))(
+        valuesSingleCol.foldLeft[MetricCalculator](new DateFormattedValuesMetricCalculator(t._1, false))(
           (m, v) => m.increment(Seq(v))),
         t._3
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
-    "return correct metric value for multi column sequence" in {
+    "return correct failure counts for single column sequence [reversed error collection]" in {
       val metricResults = paramsWithResults.map(t => (
-        valuesMultiCol.foldLeft[MetricCalculator](new DateFormattedValuesMetricCalculator(t._1))(
-          (m, v) => m.increment(v)).result()(MetricName.FormattedDate.entryName)._1,
-        t._2
+        valuesSingleCol.foldLeft[MetricCalculator](new DateFormattedValuesMetricCalculator(t._1, true))(
+          (m, v) => m.increment(Seq(v))),
+        t._4
       ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct metric value for multi column sequence" in {
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- paramsWithResults.map(t => (
+          valuesMultiCol.foldLeft[MetricCalculator](new DateFormattedValuesMetricCalculator(t._1, reversed))(
+            (m, v) => m.increment(v)).result()(MetricName.FormattedDate.entryName)._1,
+          t._2
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct failure counts for multi column sequence" in {
+    "return correct failure counts for multi column sequence [direct error collection]" in {
       val metricResults = paramsWithResults.map(t => (
-        valuesMultiCol.foldLeft[MetricCalculator](new DateFormattedValuesMetricCalculator(t._1))(
+        valuesMultiCol.foldLeft[MetricCalculator](new DateFormattedValuesMetricCalculator(t._1, false))(
           (m, v) => m.increment(v)),
         t._3
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct failure counts for multi column sequence [reversed error collection]" in {
+      val metricResults = paramsWithResults.map(t => (
+        valuesMultiCol.foldLeft[MetricCalculator](new DateFormattedValuesMetricCalculator(t._1, true))(
+          (m, v) => m.increment(v)),
+        t._4
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return zero when applied to empty sequence" in {
       val values = Seq.empty
       val metricResult = values.foldLeft[MetricCalculator](
-        new DateFormattedValuesMetricCalculator(paramsWithResults.head._1))((m, v) => m.increment(v))
+        new DateFormattedValuesMetricCalculator(paramsWithResults.head._1, false))((m, v) => m.increment(v))
       metricResult.result()(MetricName.FormattedDate.entryName)._1 shouldEqual 0
     }
   }
@@ -498,37 +666,68 @@ class BasicStringMetricsSpec extends AnyWordSpec with Matchers {
     val paramList: Seq[(Int, String)] = Seq((6, "eq"), (4, "lte"), (4, "gt"), (5, "gte"))
     val results = Seq(12, 12, 0, 4)
     val failCounts = Seq(0, 0, 12, 8)
+    val failCountsRev = Seq(12, 12, 0, 4)
 
     "return correct metric value for single column sequence" in {
       val values = (testSingleColSeq, paramList, results).zipped.toList
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringLengthValuesMetricCalculator(t._2._1, t._2._2))(
-          (m, v) => m.increment(Seq(v))).result()(MetricName.StringLength.entryName)._1,
-        t._3
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new StringLengthValuesMetricCalculator(t._2._1, t._2._2, reversed))(
+            (m, v) => m.increment(Seq(v))).result()(MetricName.StringLength.entryName)._1,
+          t._3
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for single column sequence" in {
+    "return correct fail counts for single column sequence [direct error collection]" in {
       val values = (testSingleColSeq, paramList, failCounts).zipped.toList
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringLengthValuesMetricCalculator(t._2._1, t._2._2))((m, v) => m.increment(Seq(v))),
+        t._1.foldLeft[MetricCalculator](new StringLengthValuesMetricCalculator(t._2._1, t._2._2, false))(
+          (m, v) => m.increment(Seq(v))
+        ),
+        t._3
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for single column sequence [reversed error collection]" in {
+      val values = (testSingleColSeq, paramList, failCountsRev).zipped.toList
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new StringLengthValuesMetricCalculator(t._2._1, t._2._2, true))(
+          (m, v) => m.increment(Seq(v))
+        ),
         t._3
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return correct metric value for multi column sequence" in {
       val values = (testMultiColSeq, paramList, results).zipped.toList
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringLengthValuesMetricCalculator(t._2._1, t._2._2))(
-          (m, v) => m.increment(v)).result()(MetricName.StringLength.entryName)._1,
-        t._3
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new StringLengthValuesMetricCalculator(t._2._1, t._2._2, reversed))(
+            (m, v) => m.increment(v)).result()(MetricName.StringLength.entryName)._1,
+          t._3
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for multi column sequence" in {
+    "return correct fail counts for multi column sequence [direct error collection]" in {
       val values = (testMultiColSeq, paramList, failCounts).zipped.toList
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringLengthValuesMetricCalculator(t._2._1, t._2._2))((m, v) => m.increment(v)),
+        t._1.foldLeft[MetricCalculator](new StringLengthValuesMetricCalculator(t._2._1, t._2._2, false))(
+          (m, v) => m.increment(v)
+        ),
+        t._3
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for multi column sequence [reversed error collection]" in {
+      val values = (testMultiColSeq, paramList, failCountsRev).zipped.toList
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new StringLengthValuesMetricCalculator(t._2._1, t._2._2, true))(
+          (m, v) => m.increment(v)
+        ),
         t._3
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
@@ -536,7 +735,7 @@ class BasicStringMetricsSpec extends AnyWordSpec with Matchers {
     "return zero when applied to empty sequence" in {
       val values = Seq.empty
       val metricResult = values.foldLeft[MetricCalculator](
-        new StringLengthValuesMetricCalculator(paramList.head._1, paramList.head._2)
+        new StringLengthValuesMetricCalculator(paramList.head._1, paramList.head._2, false)
       )((m, v) => m.increment(v))
       metricResult.result()(MetricName.StringLength.entryName)._1 shouldEqual 0
     }
@@ -551,37 +750,64 @@ class BasicStringMetricsSpec extends AnyWordSpec with Matchers {
     )
     val results = Seq(4, 4, 4, 2)
     val failCounts = Seq(8, 8, 8, 10)
+    val failCountsRev = Seq(4, 4, 4, 2)
 
     "return correct metric value for single column sequence" in {
       val values = (testSingleColSeq, domainList, results).zipped.toList
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringInDomainValuesMetricCalculator(t._2))(
-          (m, v) => m.increment(Seq(v))).result()(MetricName.StringInDomain.entryName)._1,
-        t._3
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new StringInDomainValuesMetricCalculator(t._2, reversed))(
+            (m, v) => m.increment(Seq(v))).result()(MetricName.StringInDomain.entryName)._1,
+          t._3
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for single column sequence" in {
+    "return correct fail counts for single column sequence [direct error collection]" in {
       val values = (testSingleColSeq, domainList, failCounts).zipped.toList
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringInDomainValuesMetricCalculator(t._2))((m, v) => m.increment(Seq(v))),
+        t._1.foldLeft[MetricCalculator](new StringInDomainValuesMetricCalculator(t._2, false))(
+          (m, v) => m.increment(Seq(v))
+        ),
+        t._3
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for single column sequence [reversed error collection]" in {
+      val values = (testSingleColSeq, domainList, failCountsRev).zipped.toList
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new StringInDomainValuesMetricCalculator(t._2, true))(
+          (m, v) => m.increment(Seq(v))
+        ),
         t._3
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return correct metric value for multi column sequence" in {
       val values = (testMultiColSeq, domainList, results).zipped.toList
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringInDomainValuesMetricCalculator(t._2))(
-          (m, v) => m.increment(v)).result()(MetricName.StringInDomain.entryName)._1,
-        t._3
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new StringInDomainValuesMetricCalculator(t._2, reversed))(
+            (m, v) => m.increment(v)).result()(MetricName.StringInDomain.entryName)._1,
+          t._3
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for multi column sequence" in {
+    "return correct fail counts for multi column sequence [direct error collection]" in {
       val values = (testMultiColSeq, domainList, failCounts).zipped.toList
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringInDomainValuesMetricCalculator(t._2))((m, v) => m.increment(v)),
+        t._1.foldLeft[MetricCalculator](new StringInDomainValuesMetricCalculator(t._2, false))((m, v) => m.increment(v)),
+        t._3
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for multi column sequence [reversed error collection]" in {
+      val values = (testMultiColSeq, domainList, failCountsRev).zipped.toList
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new StringInDomainValuesMetricCalculator(t._2, true))((m, v) => m.increment(v)),
         t._3
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
@@ -589,7 +815,7 @@ class BasicStringMetricsSpec extends AnyWordSpec with Matchers {
     "return zero when applied to empty sequence" in {
       val values = Seq.empty
       val metricResult = values.foldLeft[MetricCalculator](
-        new StringInDomainValuesMetricCalculator(domainList.head)
+        new StringInDomainValuesMetricCalculator(domainList.head, false)
       )((m, v) => m.increment(v))
       metricResult.result()(MetricName.StringInDomain.entryName)._1 shouldEqual 0
     }
@@ -604,46 +830,77 @@ class BasicStringMetricsSpec extends AnyWordSpec with Matchers {
     )
     val results = Seq(8, 8, 8, 10)
     val failCounts = Seq(4, 4, 4, 2)
+    val failCountsRev = Seq(8, 8, 8, 10)
 
     "return correct metric value for single column sequence" in {
       val values = (testSingleColSeq, domainList, results).zipped.toList
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringOutDomainValuesMetricCalculator(t._2))(
-          (m, v) => m.increment(Seq(v))).result()(MetricName.StringOutDomain.entryName)._1,
-        t._3
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new StringOutDomainValuesMetricCalculator(t._2, reversed))(
+            (m, v) => m.increment(Seq(v))).result()(MetricName.StringOutDomain.entryName)._1,
+          t._3
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for single column sequence" in {
+    "return correct fail counts for single column sequence [direct error collection]" in {
       val values = (testSingleColSeq, domainList, failCounts).zipped.toList
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringOutDomainValuesMetricCalculator(t._2))((m, v) => m.increment(Seq(v))),
+        t._1.foldLeft[MetricCalculator](new StringOutDomainValuesMetricCalculator(t._2, false))(
+          (m, v) => m.increment(Seq(v))
+        ),
+        t._3
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for single column sequence [reversed error collection]" in {
+      val values = (testSingleColSeq, domainList, failCountsRev).zipped.toList
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new StringOutDomainValuesMetricCalculator(t._2, true))(
+          (m, v) => m.increment(Seq(v))
+        ),
         t._3
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return correct metric value for multi column sequence" in {
       val values = (testMultiColSeq, domainList, results).zipped.toList
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringOutDomainValuesMetricCalculator(t._2))(
-          (m, v) => m.increment(v)).result()(MetricName.StringOutDomain.entryName)._1,
-        t._3
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new StringOutDomainValuesMetricCalculator(t._2, reversed))(
+            (m, v) => m.increment(v)).result()(MetricName.StringOutDomain.entryName)._1,
+          t._3
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for multi column sequence" in {
+    "return correct fail counts for multi column sequence [direct error collection]" in {
       val values = (testMultiColSeq, domainList, failCounts).zipped.toList
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringOutDomainValuesMetricCalculator(t._2))((m, v) => m.increment(v)),
+        t._1.foldLeft[MetricCalculator](new StringOutDomainValuesMetricCalculator(t._2, false))(
+          (m, v) => m.increment(v)
+        ),
+        t._3
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for multi column sequence [reversed error collection]" in {
+      val values = (testMultiColSeq, domainList, failCountsRev).zipped.toList
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new StringOutDomainValuesMetricCalculator(t._2, true))(
+          (m, v) => m.increment(v)
+        ),
         t._3
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return zero when applied to empty sequence" in {
       val values = Seq.empty
-      val metricResult = values.foldLeft[MetricCalculator](new StringOutDomainValuesMetricCalculator(domainList.head))(
-        (m, v) => m.increment(v)
-      )
+      val metricResult = values.foldLeft[MetricCalculator](
+        new StringOutDomainValuesMetricCalculator(domainList.head, false)
+      )((m, v) => m.increment(v))
       metricResult.result()(MetricName.StringOutDomain.entryName)._1 shouldEqual 0
     }
   }
@@ -652,46 +909,69 @@ class BasicStringMetricsSpec extends AnyWordSpec with Matchers {
     val compareValues: Seq[String] = Seq("Gpi2C7", "3.09", "5.85", "4")
     val results = Seq(4, 4, 4, 2)
     val failCounts = Seq(8, 8, 8, 10)
+    val failCountsRev = Seq(4, 4, 4, 2)
 
     "return correct metric value for single column sequence" in {
       val values = (testSingleColSeq, compareValues, results).zipped.toList
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringValuesMetricCalculator(t._2))(
-          (m, v) => m.increment(Seq(v))).result()(MetricName.StringValues.entryName)._1,
-        t._3
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new StringValuesMetricCalculator(t._2, reversed))(
+            (m, v) => m.increment(Seq(v))).result()(MetricName.StringValues.entryName)._1,
+          t._3
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for single column sequence" in {
+    "return correct fail counts for single column sequence [direct error collection]" in {
       val values = (testSingleColSeq, compareValues, failCounts).zipped.toList
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringValuesMetricCalculator(t._2))((m, v) => m.increment(Seq(v))),
+        t._1.foldLeft[MetricCalculator](new StringValuesMetricCalculator(t._2, false))((m, v) => m.increment(Seq(v))),
+        t._3
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for single column sequence [reversed error collection]" in {
+      val values = (testSingleColSeq, compareValues, failCountsRev).zipped.toList
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new StringValuesMetricCalculator(t._2, true))((m, v) => m.increment(Seq(v))),
         t._3
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return correct metric value for multi column sequence" in {
       val values = (testMultiColSeq, compareValues, results).zipped.toList
-      val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringValuesMetricCalculator(t._2))(
-          (m, v) => m.increment(v)).result()(MetricName.StringValues.entryName)._1,
-        t._3
-      ))
+      val metricResults = for {
+        reversed <- Seq(false, true)
+        metricResult <- values.map(t => (
+          t._1.foldLeft[MetricCalculator](new StringValuesMetricCalculator(t._2, reversed))(
+            (m, v) => m.increment(v)).result()(MetricName.StringValues.entryName)._1,
+          t._3
+        ))
+      } yield metricResult
       metricResults.foreach(v => v._1 shouldEqual v._2)
     }
-    "return correct fail counts for multi column sequence" in {
+    "return correct fail counts for multi column sequence [direct error collection]" in {
       val values = (testMultiColSeq, compareValues, failCounts).zipped.toList
       val metricResults = values.map(t => (
-        t._1.foldLeft[MetricCalculator](new StringValuesMetricCalculator(t._2))((m, v) => m.increment(v)),
+        t._1.foldLeft[MetricCalculator](new StringValuesMetricCalculator(t._2, false))((m, v) => m.increment(v)),
+        t._3
+      ))
+      metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
+    }
+    "return correct fail counts for multi column sequence [reversed error collection]" in {
+      val values = (testMultiColSeq, compareValues, failCountsRev).zipped.toList
+      val metricResults = values.map(t => (
+        t._1.foldLeft[MetricCalculator](new StringValuesMetricCalculator(t._2, true))((m, v) => m.increment(v)),
         t._3
       ))
       metricResults.foreach(v => v._1.getFailCounter shouldEqual v._2)
     }
     "return zero when applied to empty sequence" in {
       val values = Seq.empty
-      val metricResult = values.foldLeft[MetricCalculator](new StringValuesMetricCalculator(compareValues.head))(
-        (m, v) => m.increment(v)
-      )
+      val metricResult = values.foldLeft[MetricCalculator](
+        new StringValuesMetricCalculator(compareValues.head, false)
+      )((m, v) => m.increment(v))
       metricResult.result()(MetricName.StringValues.entryName)._1 shouldEqual 0
     }
   }

--- a/docs/en/03-job-configuration/12-JobConfigExample.md
+++ b/docs/en/03-job-configuration/12-JobConfigExample.md
@@ -167,13 +167,14 @@ jobConfig: {
       regexMatch: [
         {
           id: "table_source1_inn_regex", description: "Regex match for inn column", source: "table_source_1",
-          columns: ["inn"], params: {regex: """^\d{10}$"""}
+          columns: ["inn"], params: {regex: """^\d{10}$"""}, reversed: true
         }
       ]
       stringInDomain: [
         {
           id: "orc_data_segment_domain", source: "hdfs_orc_source",
           columns: ["segment"], params: {domain: ["FI", "MID", "SME", "INTL", "CIB"]}
+          reversed: true
         }
       ]
       topN: [


### PR DESCRIPTION
- added new parameter - `reversed` - for regular metrics which incrementation requires meeting some criterion.
- changed metric calculators for affected metrics in order to support direct and reversed error collection logic
- updated tests for metrics in accordance with aforementioned changes.
- updated documentation to describe reversible metrics and specifics of error collection for them.
- incremented job configuration version to reflect addition of new parameters for reversible metrics.
- refactored error collection logic by returning to standard spark CollectionAccumulator and limiting total number of errors collected per each metric during result processing.