### PR TITLE
feat: refactor kafka source API and enhance virtual sources resolving logic

### DIFF
--- a/checkita-core/src/main/resources/version-info.properties
+++ b/checkita-core/src/main/resources/version-info.properties
@@ -1,2 +1,2 @@
 app-version = 1.5.0
-config-api-version = 1.4
+config-api-version = 1.5

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/Enums.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/Enums.scala
@@ -31,6 +31,7 @@ object Enums {
    */
   sealed trait KafkaTopicFormat extends EnumEntry
   object KafkaTopicFormat extends Enum[KafkaTopicFormat] {
+    case object Binary extends KafkaTopicFormat
     case object String extends KafkaTopicFormat
     case object Xml extends KafkaTopicFormat
     case object Json extends KafkaTopicFormat

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Schemas.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Schemas.scala
@@ -94,15 +94,18 @@ object Schemas {
   /**
    * Avro schema configuration
    *
-   * @param id          Schema ID
-   * @param description Schema description
-   * @param schema      Path to Avro schema file (.avsc)
-   * @param metadata    List of metadata parameters specific to this schema
+   * @param id               Schema ID
+   * @param description      Schema description
+   * @param schema           Path to Avro schema file (.avsc)
+   * @param validateDefaults Boolean flag enabling or disabling default values validation in Avro schema.
+   *                         Default: `false`.
+   * @param metadata         List of metadata parameters specific to this schema
    */
   final case class AvroSchemaConfig(
                                      id: ID,
                                      description: Option[NonEmptyString],
                                      schema: URI,
+                                     validateDefaults: Boolean = false,
                                      metadata: Seq[SparkParam] = Seq.empty
                                    ) extends SchemaConfig
 

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Sources.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Sources.scala
@@ -89,31 +89,35 @@ object Sources {
   /**
    * Kafka source configuration
    *
-   * @param id              Source ID
-   * @param description     Source description
-   * @param connection      Connection ID (must be a Kafka Connection)
-   * @param topics          Sequence of topics to read
-   * @param topicPattern    Pattern that defined topics to read
-   * @param startingOffsets Json-string defining starting offsets.
-   *                        If none is set, then "earliest" is used in batch jobs and "latest is used in streaming jobs.
-   * @param endingOffsets   Json-string defining ending offset. Applicable only to batch jobs.
-   *                        If none is set then "latest" is used.
-   * @param windowBy        Source of timestamp used to build windows. Applicable only for streaming jobs!
-   *                        Default: processingTime - uses current timestamp at the moment when Spark processes row.
-   *                        Other options are:
+   * @param id               Source ID
+   * @param description      Source description
+   * @param connection       Connection ID (must be a Kafka Connection)
+   * @param topics           Sequence of topics to read
+   * @param topicPattern     Pattern that defined topics to read
+   * @param startingOffsets  Json-string defining starting offsets.
+   *                         If none is set, then "earliest" is used in batch jobs and "latest is used in streaming jobs.
+   * @param endingOffsets    Json-string defining ending offset. Applicable only to batch jobs.
+   *                         If none is set then "latest" is used.
+   * @param windowBy         Source of timestamp used to build windows. Applicable only for streaming jobs!
+   *                         Default: processingTime - uses current timestamp at the moment when Spark processes row.
+   *                         Other options are:
    *                          - eventTime - uses Kafka message creation timestamp.
    *                          - customTime(columnName) - uses arbitrary user-defined column from kafka message
    *                            (column must be of TimestampType)
-   * @param keyFormat       Message key format. Default: string.
-   * @param valueFormat     Message value format. Default: string.
-   * @param keySchema       Schema ID. Used to parse message key. Ignored when keyFormat is string.
-   *                        Mandatory for other formats.
-   * @param valueSchema     Schema ID. Used to parse message value. Ignored when valueFormat is string.
-   *                        Mandatory for other formats.
-   *                        Used to parse kafka message value.
-   * @param options         Sequence of additional Kafka options
-   * @param keyFields       Sequence of key fields (columns that identify data row)
-   * @param metadata        List of metadata parameters specific to this source
+   * @param keyFormat        Message key format. Default: string.
+   * @param valueFormat      Message value format. Default: string.
+   * @param keySchema        Schema ID. Used to parse message key. Ignored when keyFormat is string.
+   *                         Mandatory for other formats.
+   * @param valueSchema      Schema ID. Used to parse message value. Ignored when valueFormat is string.
+   *                         Mandatory for other formats.
+   *                         Used to parse kafka message value.
+   * @param subtractSchemaId Boolean flag indicating whether a kafka message schema ID encoded into its value, i.e.
+   *                         [1 Magic Byte] + [4 Schema ID Bytes] + [Message Value Binary Data].
+   *                         If set to `true`, then first five bytes are subtracted before value parsing.
+   *                         Default: `false`
+   * @param options          Sequence of additional Kafka options
+   * @param keyFields        Sequence of key fields (columns that identify data row)
+   * @param metadata         List of metadata parameters specific to this source
    */
   final case class KafkaSourceConfig(
                                       id: ID,
@@ -128,6 +132,7 @@ object Sources {
                                       valueFormat: KafkaTopicFormat = KafkaTopicFormat.String,
                                       keySchema: Option[ID] = None,
                                       valueSchema: Option[ID] = None,
+                                      subtractSchemaId: Boolean = false,
                                       options: Seq[SparkParam] = Seq.empty,
                                       keyFields: Seq[NonEmptyString] = Seq.empty,
                                       metadata: Seq[SparkParam] = Seq.empty

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/readers/SchemaReaders.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/readers/SchemaReaders.scala
@@ -171,7 +171,7 @@ object SchemaReaders {
      * @return Parsed schema
      */
     def tryToRead(config: AvroSchemaConfig)(implicit spark: SparkSession): SourceSchema = {
-      val schemaParser = new Parser()
+      val schemaParser = new Parser().setValidateDefaults(config.validateDefaults)
       val avroSchema = schemaParser.parse(new File(config.schema.value))
 
       val sparkSchema = SchemaConverters

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/readers/VirtualSourceReaders.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/readers/VirtualSourceReaders.scala
@@ -123,8 +123,8 @@ object VirtualSourceReaders {
         s"Join virtual source must have two parent sources defined. Got following: " +
           parents.map(_.id).mkString("[", ",", "]")
       )
-      val leftSrc = parents.head.df
-      val rightSrc = parents.tail.head.df
+      val leftSrc = parents.head.df.as(parents.head.id)
+      val rightSrc = parents.tail.head.df.as(parents.tail.head.id)
 
       leftSrc.join(rightSrc, config.joinBy.value, config.joinType.toString.toLowerCase)
     }
@@ -220,8 +220,8 @@ object VirtualSourceReaders {
      */
     def getDataFrame(config: AggregateVirtualSourceConfig,
                      readMode: ReadMode)(implicit settings: AppSettings,
-                                                           spark: SparkSession,
-                                                           parentSources: Map[String, Source]): DataFrame = {
+                                         spark: SparkSession,
+                                         parentSources: Map[String, Source]): DataFrame = {
       val parents = getParents(config)
       require(parents.size == 1,
         s"Aggregate virtual source must have exactly one parent source. Got following: " +

--- a/checkita-core/src/test/scala/ru/raiffeisen/checkita/context/DQContextSpec.scala
+++ b/checkita-core/src/test/scala/ru/raiffeisen/checkita/context/DQContextSpec.scala
@@ -1,0 +1,132 @@
+package ru.raiffeisen.checkita.context
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.functions.expr
+import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType, StructField, StructType}
+import org.scalatest.PrivateMethodTester
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import ru.raiffeisen.checkita.Common._
+import ru.raiffeisen.checkita.config.Enums.SparkJoinType
+import ru.raiffeisen.checkita.config.RefinedTypes.ID
+import ru.raiffeisen.checkita.config.jobconf.Sources.{AggregateVirtualSourceConfig, FilterVirtualSourceConfig, JoinVirtualSourceConfig, SelectVirtualSourceConfig, VirtualSourceConfig}
+import ru.raiffeisen.checkita.core.Source
+import ru.raiffeisen.checkita.utils.ResultUtils.{Result, liftToResult}
+
+import scala.annotation.tailrec
+
+class DQContextSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
+
+  private val context = DQContext.build(settings).getOrElse(new DQContext(settings, spark, fs))
+
+  private val emptyDF = spark.createDataFrame(
+    spark.sparkContext.emptyRDD[Row],
+    StructType(Seq(
+      StructField("c1", IntegerType, nullable = true),
+      StructField("c2", StringType, nullable = true),
+      StructField("c3", DoubleType, nullable = true)
+    ))
+  )
+  "DQContext" must {
+    "correctly read sequence of virtual sources" in {
+      val vsReader = PrivateMethod[Result[Map[String, Source]]]('readVirtualSources)
+      val nextVsGetter = PrivateMethod[(VirtualSourceConfig, Seq[VirtualSourceConfig])]('getNextVS)
+
+      val parents = liftToResult(Seq(Source("emptyDF", emptyDF)).map(s => s.id -> s).toMap)
+      val vs1 = FilterVirtualSourceConfig(
+        ID("vs1"), None,
+        Refined.unsafeApply(Seq("emptyDF")),
+        Refined.unsafeApply(Seq(expr("c1 > 0"))),
+        None, None, None
+      )
+
+      val vs2 = FilterVirtualSourceConfig(
+        ID("vs2"), None,
+        Refined.unsafeApply(Seq("emptyDF")),
+        Refined.unsafeApply(Seq(expr("c2 is not null"))),
+        None, None, None
+      )
+
+      val vs3 = JoinVirtualSourceConfig(
+        ID("vs3"), None,
+        Refined.unsafeApply(Seq("vs1", "vs2")),
+        Refined.unsafeApply(Seq("c1")),
+        SparkJoinType.Inner,
+        None, None
+      )
+
+      val vs4 = AggregateVirtualSourceConfig(
+        ID("vs4"), None,
+        Refined.unsafeApply(Seq("vs3")),
+        Refined.unsafeApply(Seq("c1")),
+        Refined.unsafeApply(Seq(
+          expr("sum(vs1.c3) as sum_c3"),
+          expr("count(vs1.c1) as row_cnt"),
+        )),
+        None, None
+      )
+
+      val vs5 = SelectVirtualSourceConfig(
+        ID("vs5"), None,
+        Refined.unsafeApply(Seq("vs4")),
+        Refined.unsafeApply(Seq(expr("sum_c3 / row_cnt as avg_value"))),
+        None, None, None
+      )
+
+      val indices = Seq(0, 8, 16)
+      val strPerm = Seq("vs1", "vs2", "vs3", "vs4", "vs5").permutations.toSeq
+        .groupBy(_.head)
+        .mapValues(sq => indices.map(idx => sq(idx)))
+        .values.flatten.toSeq
+
+
+      val vsSequences = Seq(vs1, vs2, vs3, vs4, vs5).permutations.toSeq
+        .groupBy(_.head)
+        .mapValues(sq => indices.map(idx => sq(idx)))
+        .values.flatten
+        .map(liftToResult).toSeq
+
+
+      val orderResolving = vsSequences.map{ vsSeq =>
+        @tailrec
+        def readAll(vs: Seq[VirtualSourceConfig],
+                    p: Map[String, Source],
+                    acc: Seq[VirtualSourceConfig] = Seq.empty): Seq[VirtualSourceConfig] =
+          if (vs.isEmpty) acc
+          else {
+            val (nextVs, restVs) = context invokePrivate nextVsGetter(vs, p, 0)
+            val newP = p + (nextVs.id.value -> Source(nextVs.id.value, emptyDF))
+            readAll(restVs, newP, acc :+ nextVs)
+          }
+
+        for {
+          vs <- vsSeq
+          p <- parents
+        } yield readAll(vs, p)
+      }
+
+      // test how getNextVS function resolves virtual sources order:
+      orderResolving.foreach { vsSeq =>
+        vsSeq.isRight shouldEqual true
+        val vs = vsSeq.getOrElse(Seq.empty)
+        vs.head.parents shouldEqual Seq("emptyDF") // either vs1 or vs2
+        vs.last.id.value shouldEqual "vs5"
+      }
+
+      // test how readVirtualSources function reads virtual sources:
+      val results = vsSequences.map(vsSeq => context invokePrivate vsReader(vsSeq, parents, false))
+
+      results.foreach { r =>
+        r.isRight shouldEqual true
+
+        val allSources = r.getOrElse(Map.empty)
+        allSources.isEmpty shouldEqual false
+
+        // test that all dataframes can be evaluated.
+        allSources.values.foreach(src => src.df.collect().length shouldEqual 0)
+      }
+    }
+  }
+}

--- a/docs/en/03-job-configuration/02-Schemas.md
+++ b/docs/en/03-job-configuration/02-Schemas.md
@@ -4,7 +4,7 @@ Schemas are used in Data Quality jobs for two purposes:
 
 * Provide explicit schema when reading sources without embedded schemas such as delimited or fixed width text files.
 * Provide reference schema to validate actual source schema. Schemas are used in `schemaMatch` load checks.
-  See [Schema Match Check](05-LoadChecks.md#schema-match-check).
+  See [Schema Match Check](07-LoadChecks.md#schema-match-check).
 
 Schemas are set in `schemas` section of job configuration and can be defined in different formats as described below.
 Format in which schema is defined is set in `kind` field and defines what other fields are need to be provided.
@@ -36,7 +36,7 @@ Thus, delimited definition contains following parameters:
 
 Fixed-full kind of schema definition is used to provide schemas for read fixed-width text files. The key difference from
 other schema definitions is that columns widths are also provided which is crucial information for parsing fixed-width
-files. This kind of schemas may also be used for reading delimited files and for reference in `schemaMatch` load checks.
+files. This kind of schema may also be used for reading delimited files and for reference in `schemaMatch` load checks.
 Using this type of configuration, only flat schemas can be defined (nested columns are not allowed).
 
 Fixed-fill schema definition contains following parameters:
@@ -55,7 +55,7 @@ Fixed-fill schema definition contains following parameters:
 
 Fixed-short kind of schema definition provides a more compact syntax for defining schemas used for reading fixed-width
 files. The columns are defined by their name and width only. *Subsequently, all columns will have StringType.*
-This kind of schemas may also be used for reading delimited files and for reference in `schemaMatch` load checks.
+This kind of schema may also be used for reading delimited files and for reference in `schemaMatch` load checks.
 Using this type of configuration, only flat schemas can be defined (nested columns are not allowed).
 
 Fixed-short schema definition contains following parameters:
@@ -80,6 +80,10 @@ In order to read schema from avro file it is required to supply following parame
 * `id` - *Required*. Schema ID;
 * `description` - *Optional*. Schema description;
 * `schema` - *Required*. Path to avro schema file `.avsc` to read schema from.
+* `validateDefaults` - *Optional, , default is `false`*. Boolean flag enabling or disabling default values
+  validation in Avro schema.
+* `metadata` - *Optional*. List of user-defined metadata parameters specific to this schema where each parameter
+  is a string in format:`param.name=param.value`.
 
 ## Hive Schema Configuration
 

--- a/docs/en/03-job-configuration/03-Sources.md
+++ b/docs/en/03-job-configuration/03-Sources.md
@@ -184,6 +184,9 @@ parameters:
 * `valueFormat` - *Optional, default is `string`*. Format used to decode message value.
 * `keySchema` - Schema ID used to parse message key. If key format other than `string` then schema must be provided.
 * `valueSchema` - Schema ID used to parse message value. If value format other than `string` then schema must be provided.
+* `subtractSchemaId` - *Optional, default is `false`*. Boolean flag indicating whether a kafka message schema ID is
+  encoded into its value, i.e. `[1 Magic Byte] + [4 Schema ID Bytes] + [Message Value Binary Data]`.
+  If set to `true`, then first five bytes are subtracted before value parsing.
 * `options` - *Optional*. Additional Spark parameters related to reading messages from Kafka topics such as:
   `failOnDataLoss, kafkaConsumer.pollTimeoutMs, fetchOffset.numRetries, fetchOffset.retryIntervalMs, maxOffsetsPerTrigger`.
   Parameters are provided as a strings in format of `parameterName=parameterValue`.
@@ -194,7 +197,10 @@ parameters:
 * `metadata` - *Optional*. List of user-defined metadata parameters specific to this source where each parameter
   is a string in format: `param.name=param.value`.
 
-Currently, `string`, `xml`, `json` and `avro` formats are supported to decode message key and value.
+Currently, `binary`, `string`, `xml`, `json` and `avro` formats are supported to decode message key and value.
+Note, that when `binary` format is selected, then kafka key or value is not decoded but rather selected as is.
+Thus, it is up to user to use virtual sources capabilities to cast binary column into data types suitable for
+data quality checks.
 
 > *TIP*: In order to define JSON strings, they must be enclosed in triple quotes:
 > `"""{"name1": {"name2": "value2", "name3": "value3""}}"""`.

--- a/docs/en/03-job-configuration/05-VirtualSources.md
+++ b/docs/en/03-job-configuration/05-VirtualSources.md
@@ -1,12 +1,14 @@
 # Virtual Sources Configuration
 
-Checkita framework supports creation of virtual (temporary) sources base on regular once (defined in `sources` section
+Checkita framework supports creation of virtual (temporary) sources based on regular once (defined in `sources` section
 of job configuration, as described in [Sources Configuration](03-Sources.md) chapter). Virtual sources are created by
 applying transformations to existing sources using Spark SQL API. Subsequently, metrics and checks can also be applied
 to virtual sources.
 
 It is also important to note, that virtual sources are created recursively, therefore, once virtual source is created
-it can be used to create another one in the same way as regular sources.
+it can be used to create another one in the same way as regular sources. The order in which virtual sources are defined 
+in job configuration file is not important. On the contrary, virtual sources are read in the order that correspond 
+to their dependencies on parent sources.
 
 The following types of virtual sources are supported:
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val commonsText = "org.apache.commons" % "commons-text" % "1.10.0"
   val commonsMail = "org.apache.commons" % "commons-email" % "1.5"
   val commonsValidators = "commons-validator" % "commons-validator" % "1.8.0"
-  val mustache = "com.github.spullara.mustache.java" % "compiler" %"0.9.10"
+  val mustache = "com.github.spullara.mustache.java" % "compiler" % "0.9.10"
 
   // XML support in json4s published in a separate package,
   // and for latests Spark versions (starting from 3.4) using json4x-xml would
@@ -26,7 +26,7 @@ object Dependencies {
   // database drivers:
   val postgres = "org.postgresql" % "postgresql" % "42.5.4"
   val oracle = "com.oracle.database.jdbc" % "ojdbc8" % "23.2.0.0"
-  val sqlite = "org.xerial" % "sqlite-jdbc" % "3.42.0.0"
+  val sqlite = "org.xerial" % "sqlite-jdbc" % "3.45.2.0"
   val mysql = "mysql" % "mysql-connector-java" % "8.0.33"
   val mssql = "com.microsoft.sqlserver" % "mssql-jdbc" % "12.2.0.jre8"
   val mssqlJTDS = "net.sourceforge.jtds" % "jtds" % "1.3.1"


### PR DESCRIPTION
- added support for binary format for key and value. This means, that kafka message key or value is read as is, without casting to other types. Thus, it is up to user to use virtual sources/streams functionality to cast column to a desired type suitable for data quality checks.
- added boolean flag to enable schema ID subtraction from kafka value: when schema registry is used, the schema ID is embedded into kafka value (magic byte + 4 bytes of schema ID). Therefore, in order to parse value, first it is required to subtract schema ID from it.
- changed Avro schema API by adding boolean flag that enables or disable default values checks.
- refactor logic for resolving virtual sources: now they are resolved not in order but rather with respect to their parents dependencies.
- added tests to verify virtual source resolving logic.
- documentation updated with respect to API changes.
- configuration api version is updated to 1.5
- fixes: 
    - updates SQLIte dependency version: security patch [VDB-248999]. 
    - fixed JoinVirtualSourceReader by adding aliases to dataframes that are being joined. This is needed to avoid ambiguous column referencing in the resultant dataframe.