### PR TITLE
fix: modify unique key constraint for regular metrics results table

### DIFF
--- a/checkita-core/src/main/resources/db/specific/h2/V1.5__update_pk_for_regular_metrics.sql
+++ b/checkita-core/src/main/resources/db/specific/h2/V1.5__update_pk_for_regular_metrics.sql
@@ -1,0 +1,44 @@
+ALTER TABLE "${defaultSchema}"."results_metric_regular" RENAME TO "results_metric_regular_backup";
+CREATE TABLE "${defaultSchema}"."results_metric_regular"
+(
+    "job_id"            VARCHAR(512)     NOT NULL,
+    "metric_id"         VARCHAR(512)     NOT NULL,
+    "metric_name"       VARCHAR(512)     NOT NULL,
+    "description"       TEXT,
+    "metadata"          TEXT,
+    "source_id"         VARCHAR(512)     NOT NULL,
+    "column_names"      TEXT,
+    "params"            TEXT,
+    "result"            DOUBLE PRECISION NOT NULL,
+    "additional_result" VARCHAR(2048),
+    "reference_date"    TIMESTAMP        NOT NULL,
+    "execution_date"    TIMESTAMP        NOT NULL,
+    UNIQUE ("job_id", "metric_id", "metric_name", "reference_date")
+);
+INSERT INTO "${defaultSchema}"."results_metric_regular" (
+    "job_id",
+    "metric_id",
+    "metric_name",
+    "description",
+    "metadata",
+    "source_id",
+    "column_names",
+    "params",
+    "result",
+    "additional_result",
+    "reference_date",
+    "execution_date"
+) SELECT "job_id",
+         "metric_id",
+         "metric_name",
+         "description",
+         "metadata",
+         "source_id",
+         "column_names",
+         "params",
+         "result",
+         "additional_result",
+         "reference_date",
+         "execution_date"
+FROM "${defaultSchema}"."results_metric_regular_backup";
+DROP TABLE "${defaultSchema}"."results_metric_regular_backup";

--- a/checkita-core/src/main/resources/db/specific/mssql/V1.5__update_pk_for_regular_metrics.sql
+++ b/checkita-core/src/main/resources/db/specific/mssql/V1.5__update_pk_for_regular_metrics.sql
@@ -1,0 +1,44 @@
+EXEC sp_rename '${defaultSchema}.results_metric_regular', 'results_metric_regular_backup';
+CREATE TABLE "${defaultSchema}"."results_metric_regular"
+(
+    "job_id"            VARCHAR(512)     NOT NULL,
+    "metric_id"         VARCHAR(512)     NOT NULL,
+    "metric_name"       VARCHAR(512)     NOT NULL,
+    "description"       VARCHAR(MAX),
+    "metadata"          VARCHAR(MAX),
+    "source_id"         VARCHAR(512)     NOT NULL,
+    "column_names"      VARCHAR(MAX),
+    "params"            VARCHAR(MAX),
+    "result"            DOUBLE PRECISION NOT NULL,
+    "additional_result" VARCHAR(2048),
+    "reference_date"    DATETIME         NOT NULL,
+    "execution_date"    DATETIME         NOT NULL,
+    UNIQUE ("job_id", "metric_id", "metric_name", "reference_date")
+);
+INSERT INTO "${defaultSchema}"."results_metric_regular" (
+    "job_id",
+    "metric_id",
+    "metric_name",
+    "description",
+    "metadata",
+    "source_id",
+    "column_names",
+    "params",
+    "result",
+    "additional_result",
+    "reference_date",
+    "execution_date"
+) SELECT "job_id",
+         "metric_id",
+         "metric_name",
+         "description",
+         "metadata",
+         "source_id",
+         "column_names",
+         "params",
+         "result",
+         "additional_result",
+         "reference_date",
+         "execution_date"
+FROM "${defaultSchema}"."results_metric_regular_backup";
+DROP TABLE "${defaultSchema}"."results_metric_regular_backup";

--- a/checkita-core/src/main/resources/db/specific/mysql/V1.5__update_pk_for_regular_metrics.sql
+++ b/checkita-core/src/main/resources/db/specific/mysql/V1.5__update_pk_for_regular_metrics.sql
@@ -1,0 +1,52 @@
+/*
+    We have to limit number of bytes used for job_id, metric_id and check_id by limiting maximum number of chars to 256.
+    This is required because these fields are used to build unique index and MySQL limits total size of the key
+    in index by 3072 bytes. We cannot reduce size of timestamp field, therefore, have to limit number of chars
+    in text fields.
+*/
+
+ALTER TABLE "${defaultSchema}"."results_metric_regular" RENAME TO "results_metric_regular_backup";
+CREATE TABLE "${defaultSchema}"."results_metric_regular"
+(
+    "job_id"            VARCHAR(256)     NOT NULL,
+    "metric_id"         VARCHAR(256)     NOT NULL,
+    "metric_name"       VARCHAR(128)     NOT NULL,
+    "description"       TEXT,
+    "metadata"          TEXT,
+    "source_id"         VARCHAR(512)     NOT NULL,
+    "column_names"      TEXT,
+    "params"            TEXT,
+    "result"            DOUBLE PRECISION NOT NULL,
+    "additional_result" VARCHAR(2048),
+    "reference_date"    TIMESTAMP        NOT NULL,
+    "execution_date"    TIMESTAMP        NOT NULL,
+    UNIQUE ("job_id", "metric_id", "metric_name", "reference_date")
+);
+INSERT INTO "${defaultSchema}"."results_metric_regular" (
+    "job_id",
+    "metric_id",
+    "metric_name",
+    "description",
+    "metadata",
+    "source_id",
+    "column_names",
+    "params",
+    "result",
+    "additional_result",
+    "reference_date",
+    "execution_date"
+) SELECT "job_id",
+         "metric_id",
+         "metric_name",
+         "description",
+         "metadata",
+         "source_id",
+         "column_names",
+         "params",
+         "result",
+         "additional_result",
+         "reference_date",
+         "execution_date"
+FROM "${defaultSchema}"."results_metric_regular_backup";
+
+DROP TABLE "${defaultSchema}"."results_metric_regular_backup";

--- a/checkita-core/src/main/resources/db/specific/oracle/V1.5__update_pk_for_regular_metrics.sql
+++ b/checkita-core/src/main/resources/db/specific/oracle/V1.5__update_pk_for_regular_metrics.sql
@@ -1,0 +1,45 @@
+ALTER TABLE "${defaultSchema}"."results_metric_regular" RENAME TO "results_metric_regular_backup";
+CREATE TABLE "${defaultSchema}"."results_metric_regular"
+(
+    "job_id"            VARCHAR(512)     NOT NULL,
+    "metric_id"         VARCHAR(512)     NOT NULL,
+    "metric_name"       VARCHAR(512)     NOT NULL,
+    "description"       CLOB,
+    "metadata"          CLOB,
+    "source_id"         VARCHAR(512)     NOT NULL,
+    "column_names"      CLOB,
+    "params"            CLOB,
+    "result"            DOUBLE PRECISION NOT NULL,
+    "additional_result" VARCHAR(2048),
+    "reference_date"    TIMESTAMP        NOT NULL,
+    "execution_date"    TIMESTAMP        NOT NULL,
+    UNIQUE ("job_id", "metric_id", "metric_name", "reference_date")
+);
+INSERT INTO "${defaultSchema}"."results_metric_regular" (
+    "job_id",
+    "metric_id",
+    "metric_name",
+    "description",
+    "metadata",
+    "source_id",
+    "column_names",
+    "params",
+    "result",
+    "additional_result",
+    "reference_date",
+    "execution_date"
+) SELECT "job_id",
+         "metric_id",
+         "metric_name",
+         "description",
+         "metadata",
+         "source_id",
+         "column_names",
+         "params",
+         "result",
+         "additional_result",
+         "reference_date",
+         "execution_date"
+FROM "${defaultSchema}"."results_metric_regular_backup";
+
+DROP TABLE "${defaultSchema}"."results_metric_regular_backup";

--- a/checkita-core/src/main/resources/db/specific/postgres/V1.5__update_pk_for_regular_metrics.sql
+++ b/checkita-core/src/main/resources/db/specific/postgres/V1.5__update_pk_for_regular_metrics.sql
@@ -1,0 +1,45 @@
+ALTER TABLE "${defaultSchema}"."results_metric_regular" RENAME TO "results_metric_regular_backup";
+CREATE TABLE "${defaultSchema}"."results_metric_regular"
+(
+    "job_id"            TEXT             NOT NULL,
+    "metric_id"         TEXT             NOT NULL,
+    "metric_name"       TEXT             NOT NULL,
+    "description"       TEXT,
+    "metadata"          TEXT,
+    "source_id"         TEXT             NOT NULL,
+    "column_names"      TEXT,
+    "params"            TEXT,
+    "result"            DOUBLE PRECISION NOT NULL,
+    "additional_result" TEXT,
+    "reference_date"    TIMESTAMP        NOT NULL,
+    "execution_date"    TIMESTAMP        NOT NULL,
+    UNIQUE ("job_id", "metric_id", "metric_name", "reference_date")
+);
+INSERT INTO "${defaultSchema}"."results_metric_regular" (
+    "job_id",
+    "metric_id",
+    "metric_name",
+    "description",
+    "metadata",
+    "source_id",
+    "column_names",
+    "params",
+    "result",
+    "additional_result",
+    "reference_date",
+    "execution_date"
+) SELECT "job_id",
+         "metric_id",
+         "metric_name",
+         "description",
+         "metadata",
+         "source_id",
+         "column_names",
+         "params",
+         "result",
+         "additional_result",
+         "reference_date",
+         "execution_date"
+FROM "${defaultSchema}"."results_metric_regular_backup";
+
+DROP TABLE "${defaultSchema}"."results_metric_regular_backup";

--- a/checkita-core/src/main/resources/db/specific/sqlite/V1.5__update_pk_for_regular_metrics.sql
+++ b/checkita-core/src/main/resources/db/specific/sqlite/V1.5__update_pk_for_regular_metrics.sql
@@ -1,0 +1,44 @@
+ALTER TABLE "results_metric_regular" RENAME TO "results_metric_regular_backup";
+CREATE TABLE "results_metric_regular"
+(
+    "job_id"            TEXT             NOT NULL,
+    "metric_id"         TEXT             NOT NULL,
+    "metric_name"       TEXT             NOT NULL,
+    "description"       TEXT,
+    "metadata"          TEXT,
+    "source_id"         TEXT             NOT NULL,
+    "column_names"      TEXT,
+    "params"            TEXT,
+    "result"            DOUBLE PRECISION NOT NULL,
+    "additional_result" TEXT,
+    "reference_date"    TIMESTAMP        NOT NULL,
+    "execution_date"    TIMESTAMP        NOT NULL,
+    UNIQUE ("job_id", "metric_id", "metric_name", "reference_date") ON CONFLICT REPLACE
+);
+INSERT INTO "results_metric_regular" (
+    "job_id",
+    "metric_id",
+    "metric_name",
+    "description",
+    "metadata",
+    "source_id",
+    "column_names",
+    "params",
+    "result",
+    "additional_result",
+    "reference_date",
+    "execution_date"
+) SELECT "job_id",
+         "metric_id",
+         "metric_name",
+         "description",
+         "metadata",
+         "source_id",
+         "column_names",
+         "params",
+         "result",
+         "additional_result",
+         "reference_date",
+         "execution_date"
+FROM "results_metric_regular_backup";
+DROP TABLE "results_metric_regular_backup";

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/RefinedTypes.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/RefinedTypes.scala
@@ -18,6 +18,7 @@ object RefinedTypes {
   type SparkParam = String Refined MatchesRegex[W.`"""^\\S+?\\=[\\S\\s]+$"""`.T]
   type PositiveInt = Int Refined Positive
   type FixedShortColumn = String Refined MatchesRegex[W.`"""^[^\\n\\r\\t:]+:\\d+$"""`.T]
+  type PercentileDouble = Double Refined Interval.Closed[W.`0.0`.T, W.`1.0`.T]
   type AccuracyDouble = Double Refined Interval.OpenClosed[W.`0.0`.T, W.`1.0`.T]
   type RegexPattern = String Refined Regex
 

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Checks.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Checks.scala
@@ -2,7 +2,7 @@ package ru.raiffeisen.checkita.config.jobconf
 
 import eu.timepit.refined.types.string.NonEmptyString
 import ru.raiffeisen.checkita.config.Enums.TrendCheckRule
-import ru.raiffeisen.checkita.config.RefinedTypes.{AccuracyDouble, ID, PositiveInt, SparkParam}
+import ru.raiffeisen.checkita.config.RefinedTypes.{ID, PercentileDouble, PositiveInt, SparkParam}
 import ru.raiffeisen.checkita.core.checks.CheckCalculator
 import ru.raiffeisen.checkita.core.checks.snapshot._
 import ru.raiffeisen.checkita.core.checks.trend._
@@ -61,13 +61,13 @@ object Checks {
    * @param metadata      List of metadata parameters specific to this check
    */
   final case class DifferByLtCheckConfig(
-                                    id: ID,
-                                    description: Option[NonEmptyString],
-                                    metric: NonEmptyString,
-                                    compareMetric: Option[NonEmptyString],
-                                    threshold: Option[Double],
-                                    metadata: Seq[SparkParam] = Seq.empty
-                                  ) extends SnapshotCheckConfig {
+                                          id: ID,
+                                          description: Option[NonEmptyString],
+                                          metric: NonEmptyString,
+                                          compareMetric: Option[NonEmptyString],
+                                          threshold: Option[Double],
+                                          metadata: Seq[SparkParam] = Seq.empty
+                                        ) extends SnapshotCheckConfig {
     def getCalculator: CheckCalculator = DifferByLTCheckCalculator(
       id.value, metric.value, compareMetric.map(_.value), threshold.get
     ) // there is a validation check to ensure that compareMetric and threshold are not empty.
@@ -84,13 +84,13 @@ object Checks {
    * @param metadata      List of metadata parameters specific to this check
    */
   final case class EqualToCheckConfig(
-                                    id: ID,
-                                    description: Option[NonEmptyString],
-                                    metric: NonEmptyString,
-                                    compareMetric: Option[NonEmptyString],
-                                    threshold: Option[Double],
-                                    metadata: Seq[SparkParam] = Seq.empty
-                                  ) extends SnapshotCheckConfig {
+                                       id: ID,
+                                       description: Option[NonEmptyString],
+                                       metric: NonEmptyString,
+                                       compareMetric: Option[NonEmptyString],
+                                       threshold: Option[Double],
+                                       metadata: Seq[SparkParam] = Seq.empty
+                                     ) extends SnapshotCheckConfig {
     def getCalculator: CheckCalculator = EqualToCheckCalculator(
       id.value, metric.value, compareMetric.map(_.value), threshold
     )
@@ -107,13 +107,13 @@ object Checks {
    * @param metadata      List of metadata parameters specific to this check
    */
   final case class LessThanCheckConfig(
-                                  id: ID,
-                                  description: Option[NonEmptyString],
-                                  metric: NonEmptyString,
-                                  compareMetric: Option[NonEmptyString],
-                                  threshold: Option[Double],
-                                  metadata: Seq[SparkParam] = Seq.empty
-                                ) extends SnapshotCheckConfig {
+                                        id: ID,
+                                        description: Option[NonEmptyString],
+                                        metric: NonEmptyString,
+                                        compareMetric: Option[NonEmptyString],
+                                        threshold: Option[Double],
+                                        metadata: Seq[SparkParam] = Seq.empty
+                                      ) extends SnapshotCheckConfig {
     def getCalculator: CheckCalculator = LessThanCheckCalculator(
       id.value, metric.value, compareMetric.map(_.value), threshold
     )
@@ -130,13 +130,13 @@ object Checks {
    * @param metadata      List of metadata parameters specific to this check
    */
   final case class GreaterThanCheckConfig(
-                                     id: ID,
-                                     description: Option[NonEmptyString],
-                                     metric: NonEmptyString,
-                                     compareMetric: Option[NonEmptyString],
-                                     threshold: Option[Double],
-                                     metadata: Seq[SparkParam] = Seq.empty
-                                   ) extends SnapshotCheckConfig {
+                                           id: ID,
+                                           description: Option[NonEmptyString],
+                                           metric: NonEmptyString,
+                                           compareMetric: Option[NonEmptyString],
+                                           threshold: Option[Double],
+                                           metadata: Seq[SparkParam] = Seq.empty
+                                         ) extends SnapshotCheckConfig {
     def getCalculator: CheckCalculator = GreaterThanCheckCalculator(
       id.value, metric.value, compareMetric.map(_.value), threshold
     )
@@ -156,15 +156,15 @@ object Checks {
    * @param metadata     List of metadata parameters specific to this check
    */
   final case class AverageBoundFullCheckConfig(
-                                        id: ID,
-                                        description: Option[NonEmptyString],
-                                        metric: NonEmptyString,
-                                        rule: TrendCheckRule,
-                                        windowSize: NonEmptyString,
-                                        windowOffset: Option[NonEmptyString],
-                                        threshold: AccuracyDouble,
-                                        metadata: Seq[SparkParam] = Seq.empty
-                                        ) extends TrendCheckConfig with AverageBoundCheckConfig {
+                                                id: ID,
+                                                description: Option[NonEmptyString],
+                                                metric: NonEmptyString,
+                                                rule: TrendCheckRule,
+                                                windowSize: NonEmptyString,
+                                                windowOffset: Option[NonEmptyString],
+                                                threshold: PercentileDouble,
+                                                metadata: Seq[SparkParam] = Seq.empty
+                                              ) extends TrendCheckConfig with AverageBoundCheckConfig {
     def getCalculator: CheckCalculator = AverageBoundFullCheckCalculator(
       id.value, metric.value, threshold.value, rule, windowSize.value, windowOffset.map(_.value)
     )
@@ -184,15 +184,15 @@ object Checks {
    * @param metadata     List of metadata parameters specific to this check
    */
   final case class AverageBoundUpperCheckConfig(
-                                          id: ID,
-                                          description: Option[NonEmptyString],
-                                          metric: NonEmptyString,
-                                          rule: TrendCheckRule,
-                                          windowSize: NonEmptyString,
-                                          windowOffset: Option[NonEmptyString],
-                                          threshold: AccuracyDouble,
-                                          metadata: Seq[SparkParam] = Seq.empty
-                                        ) extends TrendCheckConfig with AverageBoundCheckConfig {
+                                                 id: ID,
+                                                 description: Option[NonEmptyString],
+                                                 metric: NonEmptyString,
+                                                 rule: TrendCheckRule,
+                                                 windowSize: NonEmptyString,
+                                                 windowOffset: Option[NonEmptyString],
+                                                 threshold: PercentileDouble,
+                                                 metadata: Seq[SparkParam] = Seq.empty
+                                               ) extends TrendCheckConfig with AverageBoundCheckConfig {
     def getCalculator: CheckCalculator = AverageBoundUpperCheckCalculator(
       id.value, metric.value, threshold.value, rule, windowSize.value, windowOffset.map(_.value)
     )
@@ -212,15 +212,15 @@ object Checks {
    * @param metadata     List of metadata parameters specific to this check
    */
   final case class AverageBoundLowerCheckConfig(
-                                           id: ID,
-                                           description: Option[NonEmptyString],
-                                           metric: NonEmptyString,
-                                           rule: TrendCheckRule,
-                                           windowSize: NonEmptyString,
-                                           windowOffset: Option[NonEmptyString],
-                                           threshold: AccuracyDouble,
-                                           metadata: Seq[SparkParam] = Seq.empty
-                                         ) extends TrendCheckConfig with AverageBoundCheckConfig {
+                                                 id: ID,
+                                                 description: Option[NonEmptyString],
+                                                 metric: NonEmptyString,
+                                                 rule: TrendCheckRule,
+                                                 windowSize: NonEmptyString,
+                                                 windowOffset: Option[NonEmptyString],
+                                                 threshold: PercentileDouble,
+                                                 metadata: Seq[SparkParam] = Seq.empty
+                                               ) extends TrendCheckConfig with AverageBoundCheckConfig {
     def getCalculator: CheckCalculator = AverageBoundLowerCheckCalculator(
       id.value, metric.value, threshold.value, rule, windowSize.value, windowOffset.map(_.value)
     )
@@ -241,16 +241,16 @@ object Checks {
    * @param metadata       List of metadata parameters specific to this check
    */
   final case class AverageBoundRangeCheckConfig(
-                                           id: ID,
-                                           description: Option[NonEmptyString],
-                                           metric: NonEmptyString,
-                                           rule: TrendCheckRule,
-                                           windowSize: NonEmptyString,
-                                           windowOffset: Option[NonEmptyString],
-                                           thresholdLower: AccuracyDouble,
-                                           thresholdUpper: AccuracyDouble,
-                                           metadata: Seq[SparkParam] = Seq.empty
-                                         ) extends TrendCheckConfig with AverageBoundCheckConfig {
+                                                 id: ID,
+                                                 description: Option[NonEmptyString],
+                                                 metric: NonEmptyString,
+                                                 rule: TrendCheckRule,
+                                                 windowSize: NonEmptyString,
+                                                 windowOffset: Option[NonEmptyString],
+                                                 thresholdLower: PercentileDouble,
+                                                 thresholdUpper: PercentileDouble,
+                                                 metadata: Seq[SparkParam] = Seq.empty
+                                               ) extends TrendCheckConfig with AverageBoundCheckConfig {
     def getCalculator: CheckCalculator = AverageBoundRangeCheckCalculator(
       id.value, metric.value, thresholdLower.value, thresholdUpper.value,
       rule, windowSize.value, windowOffset.map(_.value)
@@ -269,13 +269,13 @@ object Checks {
    * @param metadata     List of metadata parameters specific to this check
    */
   final case class TopNRankCheckConfig(
-                                  id: ID,
-                                  description: Option[NonEmptyString],
-                                  metric: NonEmptyString,
-                                  targetNumber: PositiveInt,
-                                  threshold: AccuracyDouble,
-                                  metadata: Seq[SparkParam] = Seq.empty
-                                ) extends TrendCheckConfig {
+                                        id: ID,
+                                        description: Option[NonEmptyString],
+                                        metric: NonEmptyString,
+                                        targetNumber: PositiveInt,
+                                        threshold: PercentileDouble,
+                                        metadata: Seq[SparkParam] = Seq.empty
+                                      ) extends TrendCheckConfig {
     def getCalculator: CheckCalculator = TopNRankCheckCalculator(
       id.value, metric.value, targetNumber.value, threshold.value
     )

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/MetricParams.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/MetricParams.scala
@@ -144,7 +144,7 @@ object MetricParams {
    */
   final case class TDigestGeqQuantileParams(
                                              accuracyError: AccuracyDouble = 0.005,
-                                             target: AccuracyDouble
+                                             target: PercentileDouble
                                            ) extends Params
 
   /**

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/checks/CheckCalculator.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/checks/CheckCalculator.scala
@@ -18,7 +18,7 @@ abstract class CheckCalculator {
   val baseMetric: String
   val compareMetric: Option[String]
   
-  protected val windowString: Option[String]
+  protected def windowString: Option[String]
   protected val notFoundErrMsg: String = 
     s"Check $checkId for metric '$baseMetric' cannot be run: metric results were not found."
 

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/checks/trend/WindowParams.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/core/checks/trend/WindowParams.scala
@@ -11,7 +11,7 @@ trait WindowParams {
   val windowSize: String
   val windowOffset: Option[String]
 
-  val windowString: Option[String] = rule match {
+  def windowString: Option[String] = rule match {
     case TrendCheckRule.Record =>
       val windowMsg = s" over $windowSize records back"
       val offsetMsg = windowOffset.map(n => s" with offset of $n records back").getOrElse("")

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/storage/Models.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/storage/Models.scala
@@ -11,7 +11,8 @@ import java.sql.Timestamp
 
 object Models {
 
-  type UniqueResult = String :: String :: Timestamp :: HNil
+  type GeneralUniqueResult = String :: String :: Timestamp :: HNil
+  type RegularMetricUniqueResult = String :: String :: String :: Timestamp :: HNil
   type JobUniqueResult = String :: Timestamp :: HNil
 
   sealed abstract class DQEntity extends Product {
@@ -35,9 +36,6 @@ object Models {
     val additionalResult: Option[String]
     val referenceDate: Timestamp
     val executionDate: Timestamp
-    
-    val uniqueFields: UniqueResult = jobId :: metricId :: referenceDate :: HNil
-    val uniqueFieldNames: Seq[String] = Seq("jobId", "metricId", "referenceDate").map(camelToSnakeCase)
   }
 
   sealed abstract class CheckResult extends DQEntity with DescriptiveFields {
@@ -50,7 +48,7 @@ object Models {
     val referenceDate: Timestamp
     val executionDate: Timestamp
 
-    val uniqueFields: UniqueResult = jobId :: checkId :: referenceDate :: HNil
+    val uniqueFields: GeneralUniqueResult = jobId :: checkId :: referenceDate :: HNil
     val uniqueFieldNames: Seq[String] = Seq("jobId", "checkId", "referenceDate").map(camelToSnakeCase)
   }
 
@@ -67,6 +65,8 @@ object Models {
                                        referenceDate: Timestamp,
                                        executionDate: Timestamp) extends MetricResult {
     val entityType: String = "regularMetricResult"
+    val uniqueFields: RegularMetricUniqueResult = jobId :: metricId :: metricName :: referenceDate :: HNil
+    val uniqueFieldNames: Seq[String] = Seq("jobId", "metricId", "metricName", "referenceDate").map(camelToSnakeCase)
   }
 
   final case class ResultMetricComposed(jobId: String,
@@ -81,6 +81,8 @@ object Models {
                                         referenceDate: Timestamp,
                                         executionDate: Timestamp) extends MetricResult {
     val entityType: String = "composedMetricResult"
+    val uniqueFields: GeneralUniqueResult = jobId :: metricId :: referenceDate :: HNil
+    val uniqueFieldNames: Seq[String] = Seq("jobId", "metricId", "referenceDate").map(camelToSnakeCase)
   }
 
   final case class ResultCheck(jobId: String,

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/storage/Tables.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/storage/Tables.scala
@@ -42,9 +42,6 @@ class Tables(val profile: JdbcProfile) {
     def sourceId: Rep[String] = column[String]("source_id")
     def result: Rep[Double] = column[Double]("result")
     def additionalResult: Rep[Option[String]] = column[Option[String]]("additional_result")
-
-    def getUniqueCond(r: R): Rep[Boolean] =
-      jobId === r.jobId && metricId === r.metricId && referenceDate === r.referenceDate
   }
   
   sealed abstract class CheckResultTable[R <: CheckResult](tag: Tag, schema: Option[String], table: String)
@@ -80,6 +77,9 @@ class Tables(val profile: JdbcProfile) {
       referenceDate,
       executionDate
     ) <> (ResultMetricRegular.tupled, ResultMetricRegular.unapply)
+
+    def getUniqueCond(r: ResultMetricRegular): Rep[Boolean] =
+      jobId === r.jobId && metricId === r.metricId && metricName === r.metricName && referenceDate === r.referenceDate
   }
   
   class ResultMetricComposedTable(tag: Tag,schema: Option[String])
@@ -100,6 +100,9 @@ class Tables(val profile: JdbcProfile) {
       referenceDate,
       executionDate
     ) <> (ResultMetricComposed.tupled, ResultMetricComposed.unapply)
+
+    def getUniqueCond(r: ResultMetricComposed): Rep[Boolean] =
+      jobId === r.jobId && metricId === r.metricId && referenceDate === r.referenceDate
   }
 
   class ResultCheckTable(tag: Tag,schema: Option[String])


### PR DESCRIPTION
- update table definition and results classes with new unique key for regular metrics results table. This fix is required to enable storing multiple results that TopN metric yields: each record is written into storage with metric name followed by record index within TopN results.
- prepare migration scripts to change unique key. In order to make migration process similar for all supported databases, the affected table is just copied to a new one with updated unique key.
- other minor fixes:
  - add refined type for threshold arguments where values should be in [0, 1] interval. (previously the AccuracyDouble type was used which interval does not include zero).
  - fix window string evaluation for trend checks: change from `val` to `def`, in order to calculate string value by call.