### PR TITLE
feat: adding schema registry reader and corresponding schema configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ ThisBuild / organizationName := "Raiffeisen"
 ThisBuild / versionScheme    := Some("semver-spec")
 ThisBuild / publishTo        := publishRepo.value
 ThisBuild / credentials      += Credentials(Path.userHome / ".sbt" / ".credentials")
+ThisBuild / resolvers        += "Confluent IO" at "https://packages.confluent.io/maven/"
 
 scalacOptions ++= Seq(
   "-encoding", "UTF-8",
@@ -17,8 +18,6 @@ scalacOptions ++= Seq(
   "-language:reflectiveCalls",
   "-language:higherKinds"
 )
-
-resolvers += "Confluent IO" at "https://packages.confluent.io/maven/"
 
 lazy val `checkita-data-quality` = (project in file("."))
   .aggregate(`checkita-core`)

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,8 @@ scalacOptions ++= Seq(
   "-language:higherKinds"
 )
 
+resolvers += "Confluent IO" at "https://packages.confluent.io/maven/"
+
 lazy val `checkita-data-quality` = (project in file("."))
   .aggregate(`checkita-core`)
   .settings(publish / skip := true)

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/RefinedTypes.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/RefinedTypes.scala
@@ -35,7 +35,8 @@ object RefinedTypes {
   type SingleElemStringSeq = Seq[String] Refined Size[Equal[W.`1`.T]]
   type DoubleElemStringSeq = Seq[String] Refined Size[Equal[W.`2`.T]]
   type MultiElemStringSeq = Seq[String] Refined MinSize[W.`2`.T]
-
+  type NonEmptyURISeq = Seq[URI] Refined NonEmpty
+  
   /**
    * Refinements for double sequences:
    */

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Schemas.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/config/jobconf/Schemas.scala
@@ -4,7 +4,8 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.types.string.NonEmptyString
 import org.apache.spark.sql.types.DataType
-import ru.raiffeisen.checkita.config.RefinedTypes.{FixedShortColumn, ID, PositiveInt, SparkParam, URI}
+import ru.raiffeisen.checkita.config.RefinedTypes.{FixedShortColumn, ID, NonEmptyURISeq, PositiveInt, SparkParam, URI}
+import ru.raiffeisen.checkita.config.jobconf.Connections.ConnectionConfig
 
 object Schemas {
 
@@ -98,7 +99,6 @@ object Schemas {
    * @param description      Schema description
    * @param schema           Path to Avro schema file (.avsc)
    * @param validateDefaults Boolean flag enabling or disabling default values validation in Avro schema.
-   *                         Default: `false`.
    * @param metadata         List of metadata parameters specific to this schema
    */
   final case class AvroSchemaConfig(
@@ -128,5 +128,34 @@ object Schemas {
                                      excludeColumns: Seq[NonEmptyString] = Seq.empty,
                                      metadata: Seq[SparkParam] = Seq.empty
                                    ) extends SchemaConfig
+
+
+  /**
+   * Schema configuration that is used to read schema from
+   * Confluent Schema Registry.
+   *
+   * @param id               Schema ID
+   * @param description      Schema description
+   * @param baseUrls         List of urls to connect to Schema Registry
+   * @param schemaId         Schema ID to search in schema registry
+   * @param schemaSubject    Schema subject to search in schema registry 
+   * @param version          Schema version (by default latest available version is fetched)
+   * @param validateDefaults Boolean flag enabling or disabling default values validation in Avro schema.
+   * @param properties       List of additional connection properties: sequence of strings in format `key=value`.
+   * @param headers          List of additional HTML headers: sequence of strings in format `key=value`.
+   * @param metadata         List of metadata parameters specific to this schema
+   */
+  final case class RegistrySchemaConfig(
+                                         id: ID,
+                                         description: Option[NonEmptyString],
+                                         baseUrls: NonEmptyURISeq,
+                                         schemaId: Option[Int],
+                                         schemaSubject: Option[NonEmptyString],
+                                         version: Option[Int],
+                                         validateDefaults: Boolean = false,
+                                         properties: Seq[SparkParam] = Seq.empty,
+                                         headers: Seq[SparkParam] = Seq.empty,
+                                         metadata: Seq[SparkParam] = Seq.empty
+                                       ) extends SchemaConfig
 
 }

--- a/checkita-core/src/main/scala/ru/raiffeisen/checkita/connections/schemaregistry/SchemaRegistryConnection.scala
+++ b/checkita-core/src/main/scala/ru/raiffeisen/checkita/connections/schemaregistry/SchemaRegistryConnection.scala
@@ -1,0 +1,157 @@
+package ru.raiffeisen.checkita.connections.schemaregistry
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema
+import ru.raiffeisen.checkita.config.jobconf.Schemas.RegistrySchemaConfig
+import ru.raiffeisen.checkita.utils.Common.paramsSeqToMap
+
+import scala.collection.JavaConverters._
+import scala.jdk.OptionConverters.RichOptional
+
+/**
+ * Schema registry connection used to obtain AVRO schemas from Confluent Kafka Schema Registry.
+ * given either their ID or a subject. Also possible to fetch schema with explicit version.
+ * By default latest version is obtained.
+ *
+ * @note At this point only AVRO schemas are supported.
+ * @note This connection is not used to read any data, therefore, it does not extend DQConnection.
+ * @param config Registry-kind schema configuration
+ */
+case class SchemaRegistryConnection(config: RegistrySchemaConfig) {
+  
+  private val cacheCapacity: Int = 10
+
+  /**
+   * Implicit conversion used to wrap map of properties into an option.
+   *
+   * @param value Properties to wrap into an option.
+   */
+  implicit class MapOps(value: Map[String, String]) {
+    def toOptionMap: Option[Map[String, String]] =
+      Some(value).flatMap(v => if (v.isEmpty) None else Some(v))
+  }
+
+  /**
+   * Builds Confluent Kafka Schema Registry Client.
+   * Users can provide additional connection properties as well as html headers.
+   * Thus, different client builders are used depending on the input. 
+   * 
+   * @return Schema registry client instance
+   */
+  private def getClient: CachedSchemaRegistryClient = {
+    val baseUrls = config.baseUrls.value.map(_.value).asJava
+    val connProps = paramsSeqToMap(config.properties.map(_.value)).toOptionMap
+    val connHeaders = paramsSeqToMap(config.headers.map(_.value)).toOptionMap
+    val nullProps: java.util.Map[String, Any] = null 
+    (connProps, connHeaders) match {
+      case (Some(props), Some(headers)) => 
+        new CachedSchemaRegistryClient(baseUrls, cacheCapacity, props.asJava, headers.asJava)
+      case (Some(props), None) => new CachedSchemaRegistryClient(baseUrls, cacheCapacity, props.asJava)
+      case (None, Some(headers)) => 
+        new CachedSchemaRegistryClient(baseUrls, cacheCapacity, nullProps, headers.asJava)
+      case _ => new CachedSchemaRegistryClient(baseUrls, cacheCapacity)
+    }
+  }
+
+  /**
+   * Confluent Kafka Schema Registry Client
+   *
+   * @note Make it lazy so the client won't be build until used.
+   */
+  private lazy val client = getClient
+
+  /**
+   * Parses schema obtained from Schema registry and returns its canonical string representation.
+   *
+   * @param schema Schema to parse.
+   * @return Canonical string representation of the schema.
+   * @note At this point only AVRO schemas are supported.
+   */
+  private def getCanonicalString(schema: Schema): String = { 
+    val schemaType = schema.getSchemaType
+    val schemaRef = s"schema (id = ${schema.getId}, subject = ${schema.getSubject}, version = ${schema.getVersion})"
+    if (schemaType == null || schemaType == AvroSchema.TYPE) {
+      client.parseSchema(schema).toScala.getOrElse(throw new IllegalArgumentException(
+        s"Unable to parse registry $schemaRef."
+      )).canonicalString()
+    } else throw new IllegalArgumentException(s"Unsupported schema type of '$schemaType' for $schemaRef.")
+  }
+
+  /**
+   * Get schema from registry by schema subject and version.
+   *
+   * @param subject Schema subject
+   * @param version Schema version
+   * @return Schema object.
+   */
+  private def getSchema(subject: String, version: Int): Schema = client.getByVersion(subject, version, false)
+
+  /**
+   * Get all schema versions by its ID.
+   *
+   * @param id Schema ID
+   * @return Sequence of tuples (subject, version)
+   */
+  private def getAllVersionsById(id: Int): Seq[(String, Int)] = 
+    client.getAllVersionsById(id).asScala.map(sv => (sv.getSubject, sv.getVersion.toInt)).toSeq
+
+  /**
+   * Get all schema versions by its subject.
+   *
+   * @param subject Schema subject
+   * @return Sequence of tuples (subject, version)
+   */
+  private def getAllVersionsBySubject(subject: String): Seq[(String, Int)] =
+    client.getAllVersions(subject).asScala.map(v => (subject, v.toInt))
+
+  /**
+   * Gets schema version to read: 
+   *   - if explicit version is provided, then checks for its presence in registry and returns this version.
+   *   - if explicit version is not provided, then returns latest (maximum) available version.
+   *
+   * @param allVersions Sequence of all versions for schema of interest.
+   * @param version     Optional explicit version.
+   * @return Tuple of (subject, version) to be read.
+   */
+  private def getVersionToRead(allVersions: Seq[(String, Int)], version: Option[Int]): (String, Int) = 
+    version match {
+      case Some(ver) => 
+        val versionFiltered = allVersions.filter(_._2 == ver)
+        if (versionFiltered.nonEmpty) versionFiltered.head
+        else throw new IllegalArgumentException(
+          s"Schema with subject ${allVersions.head._1} does not have version $ver."
+        )
+      case None => allVersions.maxBy(_._2)
+    }
+
+  /**
+   * Reads schema from registry provided by its ID and optional explicit version.
+   *
+   * @param id      Schema ID
+   * @param version Optional schema version
+   * @return Schema canonical string representation
+   */
+  def getSchemaById(id: Int, version: Option[Int]): String = {
+    val (subj, ver) = getVersionToRead(
+      getAllVersionsById(id),
+      version
+    )
+    getCanonicalString(getSchema(subj, ver))
+  }
+
+  /**
+   * Reads schema from registry provided by its subject and optional explicit version.
+   *
+   * @param subject Schema subject
+   * @param version Optional schema version
+   * @return Schema canonical string representation
+   */
+  def getSchemaBySubject(subject: String, version: Option[Int]): String = {
+    val (subj, ver) = getVersionToRead(
+      getAllVersionsBySubject(subject),
+      version
+    )
+    getCanonicalString(getSchema(subj, ver))
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,6 +45,9 @@ object Dependencies {
   val flywayOracle = "org.flywaydb" % "flyway-database-oracle" % flywayVersion
   val flywayMSSQL = "org.flywaydb" % "flyway-sqlserver" % flywayVersion
 
+//  // Schema Registry:
+  val schemaRegistry = "io.confluent" % "kafka-schema-registry-client" % "7.6.0"
+  
   val scalaTest = "org.scalatest" %% "scalatest" % "3.2.15" % Test
   
   val checkita_core: Seq[ModuleID] = Seq(
@@ -74,6 +77,7 @@ object Dependencies {
     flywayMySQL,
     flywayOracle,
     flywayMSSQL,
+    schemaRegistry,
     scalaTest
   )
 


### PR DESCRIPTION
- added connection class that implements client to Confluent Schema registry and appropriate methods to fetch schemas from registry.
- added registry schema configuration that will utilize aforementioned connection.
- updated schema readers to enable reading schemas from registry.
- added some new refined types and pre-validation for registry-kind schema definition.
- updated project dependencies to add kafka-registry-client by confluent.io.