### PR TITLE
chore: revert 2.0.0 release commit [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Checkita Data Quality
 
-**Latest Version: 2.0.0**
+**Latest Version: 1.7.2**
 
 **Checkita** is a data quality framework written is Scala 2 which uses Spark 3.2+ as a computation core.
 This framework is used to perform parallel and distributed quality checks on big data environments.

--- a/checkita-core/src/main/resources/version-info.properties
+++ b/checkita-core/src/main/resources/version-info.properties
@@ -1,2 +1,2 @@
-app-version = 2.0.0
+app-version = 1.7.2
 config-api-version = 2.0

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -1,35 +1,3 @@
-## [2.0.0](https://github.com/Raiffeisen-DGTL/checkita-data-quality/compare/v1.7.2...v2.0.0) (2024-06-21)
-
-
-### Features
-
-* Checkita 2.0 release ([#45](https://github.com/Raiffeisen-DGTL/checkita-data-quality/issues/45)) ([e747659](https://github.com/Raiffeisen-DGTL/checkita-data-quality/commit/e7476598ada2b681ee6be478e5dce0e913799b0f))
-
-
-### BREAKING CHANGES
-
-* major updates to Checkita Core that enables new
-functionality and enhances existing one.
-
-* new metrics engine based on Spark DF-API: improves stability and
-performance of regular metrics computation. Supported in batch-jobs
-only.
-* checkpointing for streaming application: restart your application from
-the same point where it stopped (or crushed).
-* Checkita API Server - experimental MVP service that provides basic
-functionality to work with configurations and DQ Storage.
-* regular metrics refactoring to comply with SQL standards.
-* new type of metrics: TREND metrics. Enables computing various
-statistics over historical metric results.
-* new type of checks: EXPRESSION. Allows to define check pass condition
-using arbitrary boolean expression.
-* enhanced formulas (for both composed metrics and expression checks):
-formulas now supports basic mathematical functions.
-* new Swagger documentation covering both Checkita Configurations and
-API methods (still in development, will be completed shortly)
-* support of Confluent Schema Registry to read schemas from.
-* minor bug fixes.
-
 ## [1.7.2](https://github.com/Raiffeisen-DGTL/checkita-data-quality/compare/v1.7.1...v1.7.2) (2024-06-21)
 
 

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,3 +1,3 @@
 object Version {
-  val releaseVersion = "2.0.0"
+  val releaseVersion = "1.7.2"
 }


### PR DESCRIPTION
This reverts commit f5de74e9da912845ad3a9f9d7a94ade55b93d6bc.