### PR TITLE
fix: algebird test

### DIFF
--- a/checkita-core/src/test/scala/org/checkita/dqf/core/metrics/rdd/regular/AlgebirdRDDMetricsSpec.scala
+++ b/checkita-core/src/test/scala/org/checkita/dqf/core/metrics/rdd/regular/AlgebirdRDDMetricsSpec.scala
@@ -158,7 +158,9 @@ class AlgebirdRDDMetricsSpec extends AnyWordSpec with Matchers {
             (m, v) => m.increment(Seq(v))).result()(MetricName.ApproximateSequenceCompleteness.entryName)._1,
           t._3
         ))
-        metricResults.foreach(v => v._1 shouldEqual v._2)
+        metricResults.foreach{case (actual, expected)  =>
+          actual should (be >= expected - 0.02 and be <= expected + 0.02)
+        }
       }
     }
 

--- a/checkita-core/src/test/scala/org/checkita/dqf/core/metrics/rdd/regular/AlgebirdRDDMetricsSpec.scala
+++ b/checkita-core/src/test/scala/org/checkita/dqf/core/metrics/rdd/regular/AlgebirdRDDMetricsSpec.scala
@@ -31,7 +31,7 @@ class AlgebirdRDDMetricsSpec extends AnyWordSpec with Matchers {
         t._2
       ))
       metricResults.foreach { t =>
-        t._1(MetricName.ApproximateDistinctValues.entryName)._1 shouldEqual t._2
+        t._1(MetricName.ApproximateDistinctValues.entryName)._1 should (be >= t._2 - accuracy and be <= t._2 + accuracy)
       }
     }
 


### PR DESCRIPTION
- In the tests for HyperLogLog metrics, a comparison is introduced taking into account the permissible error in order to avoid errors caused by small probabilistic deviations.