### PR TITLE
fix: added checkpoint initialization and validation for kafka streams

### DIFF
--- a/checkita-core/src/main/scala/org/checkita/dqf/config/appconf/StreamConfig.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/config/appconf/StreamConfig.scala
@@ -25,7 +25,7 @@ case class StreamConfig(
                          allowEmptyWindows: Boolean = false,
                          checkpointDir: Option[URI] = None
                        ) {
-  // random column names are generated to be used for windowing:
+  // random column names are generated to be used for windowing and checkpointing:
   lazy val windowTsCol: String = UUID.randomUUID.toString.replace("-", "")
   lazy val eventTsCol: String = UUID.randomUUID.toString.replace("-", "")
   lazy val checkpointCol: String = UUID.randomUUID.toString.replace("-", "")

--- a/checkita-core/src/main/scala/org/checkita/dqf/connections/DQStreamingConnection.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/connections/DQStreamingConnection.scala
@@ -2,7 +2,7 @@ package org.checkita.dqf.connections
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.checkita.dqf.appsettings.AppSettings
-import org.checkita.dqf.core.streaming.Checkpoints.{Checkpoint, KafkaCheckpoint}
+import org.checkita.dqf.core.streaming.Checkpoints.Checkpoint
 import org.checkita.dqf.readers.SchemaReaders.SourceSchema
 
 /**
@@ -18,7 +18,7 @@ trait DQStreamingConnection { this: DQConnection =>
    * @param sourceConfig Kafka source configuration
    * @return Kafka checkpoint
    */
-  def initCheckpoint(sourceConfig: SourceType): KafkaCheckpoint
+  def initCheckpoint(sourceConfig: SourceType): CheckpointType
 
   /**
    * Validates checkpoint structure and makes updates in case if

--- a/checkita-core/src/main/scala/org/checkita/dqf/connections/DQStreamingConnection.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/connections/DQStreamingConnection.scala
@@ -2,27 +2,47 @@ package org.checkita.dqf.connections
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.checkita.dqf.appsettings.AppSettings
-import org.checkita.dqf.core.streaming.Checkpoints.Checkpoint
+import org.checkita.dqf.core.streaming.Checkpoints.{Checkpoint, KafkaCheckpoint}
 import org.checkita.dqf.readers.SchemaReaders.SourceSchema
 
 /**
  * Trait to be mix in connections that can read streams.
  */
 trait DQStreamingConnection { this: DQConnection =>
+  
+  type CheckpointType <: Checkpoint
 
+  /**
+   * Creates initial checkpoint for provided Kafka source configuration.
+   *
+   * @param sourceConfig Kafka source configuration
+   * @return Kafka checkpoint
+   */
+  def initCheckpoint(sourceConfig: SourceType): KafkaCheckpoint
+
+  /**
+   * Validates checkpoint structure and makes updates in case if
+   * checkpoint structure needs to be changed.
+   *
+   * @param checkpoint   Checkpoint to validate and fix (if needed).
+   * @param sourceConfig Source configuration
+   * @return Either original checkpoint if it is valid or a fixed checkpoint.
+   */
+  def validateOrFixCheckpoint(checkpoint: CheckpointType, sourceConfig: SourceType): CheckpointType
+  
   /**
    * Loads stream into a dataframe given the stream configuration
    *
    * @param sourceConfig Stream configuration
+   * @param checkpoint   Checkpoint for given stream configuration
    * @param settings     Implicit application settings object
    * @param spark        Implicit spark session object
    * @param schemas      Implicit Map of all explicitly defined schemas (schemaId -> SourceSchema)
-   * @param checkpoints Map of initial checkpoints read from checkpoint directory
    * @return Spark Streaming DataFrame
    */
-  def loadDataStream(sourceConfig: SourceType)
+  def loadDataStream(sourceConfig: SourceType,
+                     checkpoint: CheckpointType)
                     (implicit settings: AppSettings,
                      spark: SparkSession,
-                     schemas: Map[String, SourceSchema],
-                     checkpoints: Map[String, Checkpoint]): DataFrame
+                     schemas: Map[String, SourceSchema]): DataFrame
 }

--- a/checkita-core/src/main/scala/org/checkita/dqf/connections/kafka/KafkaConnection.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/connections/kafka/KafkaConnection.scala
@@ -14,7 +14,7 @@ import org.checkita.dqf.config.Enums.KafkaTopicFormat
 import org.checkita.dqf.config.jobconf.Connections.KafkaConnectionConfig
 import org.checkita.dqf.config.jobconf.Sources.KafkaSourceConfig
 import org.checkita.dqf.connections.{DQConnection, DQStreamingConnection}
-import org.checkita.dqf.core.streaming.Checkpoints.{Checkpoint, KafkaCheckpoint}
+import org.checkita.dqf.core.streaming.Checkpoints.KafkaCheckpoint
 import org.checkita.dqf.readers.SchemaReaders.SourceSchema
 import org.checkita.dqf.utils.Common.{jsonFormats, paramsSeqToMap}
 import org.checkita.dqf.utils.ResultUtils._

--- a/checkita-core/src/main/scala/org/checkita/dqf/context/DQBatchJob.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/context/DQBatchJob.scala
@@ -131,7 +131,8 @@ final case class DQBatchJob(jobConfig: JobConfig,
     logPreMsg()
     // Run storage migration if necessary
     val migrationState = runStorageMigration(storageStage)
-    val resSet = processAll(BatchRegularMetricProcessor, migrationState)
+    // Continue to run job only if storage migration was successful (or omitted):
+    val resSet = migrationState.flatMap(_ => processAll(BatchRegularMetricProcessor))
     resSet.tap(_ => logPostMsg())
   }
 }

--- a/checkita-core/src/main/scala/org/checkita/dqf/context/DQContext.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/context/DQContext.scala
@@ -523,7 +523,10 @@ class DQContext(settings: AppSettings, spark: SparkSession, fs: FileSystem) exte
     log.info(s"$checkpointStage Reading checkpoint.")
     val bufferCheckpoint = jobConfig.getJobHash.mapValue { jh =>
       settings.streamConfig.checkpointDir match {
-        case Some(dir) => CheckpointIO.readCheckpoint(dir.value, jobId, jh)
+        case Some(dir) => 
+          log.info(s"$checkpointStage Reading from checkpoint directory: ${dir.value}")
+          log.info(s"$checkpointStage Searching checkpoint for jobId = '$jobId' and jobHas = '$jh'")
+          CheckpointIO.readCheckpoint(dir.value, jobId, jh)
         case None => 
           log.info(s"$checkpointStage Checkpoint directory is not set.")
           None

--- a/checkita-core/src/main/scala/org/checkita/dqf/context/DQJob.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/context/DQJob.scala
@@ -581,14 +581,12 @@ trait DQJob extends Logging {
    * Top-level processing function: aggregates and runs all processing stages in required order.
    *
    * @param regularMetricsProcessor Regular metric processor used to calculate regular metric results.
-   * @param migrationState          Status of storage migration run
    * @param stagePrefix             Prefix to stage names. Used for logging in streaming applications to
    *                                indicate window for which results are processed.
    * @param settings                Implicit application settings object
    * @return Either final results set or a list of processing errors
    */
   protected def processAll(regularMetricsProcessor: RegularMetricsProcessor,
-                           migrationState: Result[String],
                            stagePrefix: Option[String] = None)
                           (implicit settings: AppSettings): Result[ResultSet] = {
 
@@ -634,7 +632,7 @@ trait DQJob extends Logging {
       metricErrors
     )
     // Save results to storage
-    val resSaveState = migrationState.flatMap(_ => saveResults(getStage(storageStage), resSet))
+    val resSaveState = saveResults(getStage(storageStage), resSet)
 
     // process targets:
     val saveTargetsState = processTargets(getStage(targetsStage), resSet)

--- a/checkita-core/src/main/scala/org/checkita/dqf/core/metrics/rdd/RDDMetricStreamProcessor.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/core/metrics/rdd/RDDMetricStreamProcessor.scala
@@ -80,7 +80,15 @@ object RDDMetricStreamProcessor extends RDDMetricProcessor with Logging {
         s". Please ensure that keyFields are always exist within streamed messages."
       )
 
-      val metricsByColumns = getGroupedMetrics(streamMetrics, df.schema.fieldNames)
+      // exclude special columns used for windowing and checkpointing:
+      val metricsByColumns = getGroupedMetrics(
+        streamMetrics,
+        df.schema.fieldNames.filterNot(Seq(
+          streamConf.windowTsCol,
+          streamConf.eventTsCol,
+          streamConf.checkpointCol
+        ).contains)
+      )
 
       // get and register metric error accumulator:
       val metricErrorAccumulator = getAndRegisterErrorAccumulator

--- a/checkita-core/src/main/scala/org/checkita/dqf/storage/Models.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/storage/Models.scala
@@ -1,7 +1,7 @@
 package org.checkita.dqf.storage
 
 import org.checkita.dqf.appsettings.AppSettings
-import org.checkita.dqf.config.IO.readJobConfig
+import org.checkita.dqf.config.Enums.CheckFailureTolerance
 import org.checkita.dqf.core.CalculatorStatus
 import org.checkita.dqf.utils.Common.camelToSnakeCase
 import shapeless.{::, HList, HNil}
@@ -235,14 +235,12 @@ object Models {
       val status = if (failedChecks.length + failedLoadChecks.length == 0) "SUCCESS" else "FAILURE"
       val failedChk = failedChecks ++ failedLoadChecks
 
-      val failureToleranceViolationChecks: Seq[String] = settings.checkFailureTolerance.entryName match {
-        case "Critical" =>
+      val failureToleranceViolationChecks: Seq[String] = settings.checkFailureTolerance match {
+        case CheckFailureTolerance.Critical => 
           (checks ++ loadChecks)
             .filter(r => r.isCritical && r.status == "Failure")
             .map(_.checkId)
-
-        case "All" if failedChk.nonEmpty =>
-          failedChk
+        case CheckFailureTolerance.All if failedChk.nonEmpty => failedChk
         case _ => Seq.empty
       }
       val summary = ResultSummaryMetrics(

--- a/checkita-core/src/main/scala/org/checkita/dqf/storage/Serialization.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/storage/Serialization.scala
@@ -88,8 +88,10 @@ object Serialization {
      * @param value JValue to cast to string
      * @return String representation of JValue
      */
-    private def JValueToString(value: Any): String = value match {
+    private def jValueToString(value: Any): String = value match {
       case jStr: JString => jStr.extract[String]
+      case jDbl: JDouble => jDbl.num.toString
+      case jBool: JBool => jBool.value.toString
       case jArr: JArray => write(jArr)
       case jObj: JObject => write(jObj)
       case jMap: Map[_, _] => write(jMap)
@@ -140,7 +142,7 @@ object Serialization {
      * @return Spark Row with result data
      */
     def toRow: Row = Row.fromSeq(
-      unifiedSchema.map(c => JValueToString(unifiedRepr(c.name)))
+      unifiedSchema.map(c => jValueToString(unifiedRepr(c.name)))
     )
 
     /**
@@ -151,14 +153,14 @@ object Serialization {
      *       Thus, tsv format with flat structure is more appropriated for visual inspection.
      */
     def toTsvString: String = flatRepr.map{
-      case (_, value) => JValueToString(value)
+      case (_, value) => jValueToString(value)
     }.mkString("\t")
 
     /**
      * Gets flattened map of field name to string representation of field values.
      * @return Map fieldName -> fieldValue as string
      */
-    def getFieldsMap: Map[String, String] = flatRepr.map{ case (k, v) => (k, JValueToString(v)) }.toMap
+    def getFieldsMap: Map[String, String] = flatRepr.map{ case (k, v) => (k, jValueToString(v)) }.toMap
     
     /** Getter to retrieve TSV header (conforms to flattened tsv string) */
     def getTsvHeader: String = getFields.mkString("\t")


### PR DESCRIPTION
- implemented fixes resolve issues regarding restarting streaming applications starting from checkpoint:
  - checkpoint is ensured to have offsets for all topics and partitions for which stream is subscribed
  - checkpoint is ensured to catch up newly created partitions starting from `earliest` offsets
  - fixed `*` expansion in RDD metric processor to filter out internal columns related to stream windowing and checkpointing
- other minor fixes include:
  - do not proceed with further application running when migration wasn't successful
  - add explicit double and boolean JValue conversion to string in Serialization module.
  - added more detailed logging for checkpoint reading