### PR TITLE
fix: resolve bugs related to minimum watermark search and kafka initial offsets:

### DIFF
--- a/checkita-core/src/main/scala/org/checkita/dqf/context/DQStreamWindowJob.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/context/DQStreamWindowJob.scala
@@ -91,13 +91,14 @@ final case class DQStreamWindowJob(jobConfig: JobConfig,
    * @return Sequence of windows ready to be processed.
    */
   private def getWindowsToProcess: Seq[Long] = {
-    val currentWatermarks = buffer.watermarks.readOnlySnapshot()
+    val minWatermark = buffer.watermarks.readOnlySnapshot()
       .filter{ case (k, _) => processedSources.contains(k) }
-      .filter{ case (_, v) => v != Long.MinValue }
-      .values.toSeq
+      .values.min
+
+//      .filter{ case (_, v) => v != Long.MinValue }
 
     // -1 if none of the streams has updated its watermark value:
-    val minWatermark = if (currentWatermarks.isEmpty) -1 else currentWatermarks.min
+//    val minWatermark = if (currentWatermarks.isEmpty) -1 else currentWatermarks.min
 
     log.debug(s"$bufferStage Minimum watermark: $minWatermark")
 

--- a/checkita-core/src/main/scala/org/checkita/dqf/context/DQStreamWindowJob.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/context/DQStreamWindowJob.scala
@@ -95,11 +95,6 @@ final case class DQStreamWindowJob(jobConfig: JobConfig,
       .filter{ case (k, _) => processedSources.contains(k) }
       .values.min
 
-//      .filter{ case (_, v) => v != Long.MinValue }
-
-    // -1 if none of the streams has updated its watermark value:
-//    val minWatermark = if (currentWatermarks.isEmpty) -1 else currentWatermarks.min
-
     log.debug(s"$bufferStage Minimum watermark: $minWatermark")
 
     val filterWindows = (windows: Iterable[(String, Long)]) =>


### PR DESCRIPTION
- Minimum watermark now take into account streams that have not yet received any messages (their watermark is Long.MinValue).

- Offsets for kafka topic partitions were decremented by 1 during checkpoint initialization. This is done due to actual stream reading starts from (checkpoint_offset + 1).