### PR TITLE
feat: add Generic JDBC and Iceberg connectors

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,81 @@
+name: Integration Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - synchronize
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 3 * * *'  # nightly 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  integration-tests:
+    if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - scala-version: '2.12'
+            spark-version: '3.2.0'
+          - scala-version: '2.13'
+            spark-version: '3.5.1'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Set JVM Options
+        run: |
+          echo "-Xmx2G" > .jvmopts
+          echo "-Xms1G" >> .jvmopts
+          echo "-Xss100m" >> .jvmopts
+      - name: Tune kernel parameters for Vertica/OpenSearch
+        run: sudo sysctl -w vm.max_map_count=262144
+      - name: Run Integration Tests for Scala ${{ matrix.scala-version }} and Spark ${{ matrix.spark-version }}
+        run: sbt -DASSY_MODE=WITHSPARK -DSCALA_VERSION=${{ matrix.scala-version }} -DSPARK_VERSION=${{ matrix.spark-version }} -Duser.timezone="Europe/Moscow" integrationTest
+
+  integration-tests-nightly:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        scala-version: ['2.12', '2.13']
+        spark-version: ['3.2.0', '3.2.4', '3.3.3', '3.4.1', '3.5.1']
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Set JVM Options
+        run: |
+          echo "-Xmx2G" > .jvmopts
+          echo "-Xms1G" >> .jvmopts
+          echo "-Xss100m" >> .jvmopts
+      - name: Tune kernel parameters for Vertica/OpenSearch
+        run: sudo sysctl -w vm.max_map_count=262144
+      - name: Run Integration Tests for Scala ${{ matrix.scala-version }} and Spark ${{ matrix.spark-version }}
+        run: sbt -DASSY_MODE=WITHSPARK -DSCALA_VERSION=${{ matrix.scala-version }} -DSPARK_VERSION=${{ matrix.spark-version }} -Duser.timezone="Europe/Moscow" integrationTest

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,14 @@ ThisBuild / credentials += Credentials(Path.userHome / ".sbt" / ".credentials")
 ThisBuild / resolvers += "Confluent IO" at "https://packages.confluent.io/maven/"
 ThisBuild / scalacOptions ++= Utils.getScalacOptions(scalaVersion.value)
 
+addCommandAlias("integrationTest",
+  "; set `checkita-core` / Test / testOptions := Seq()" +
+  "; checkita-core / testOnly" +
+    " org.checkita.dqf.connections.jdbc.GenericJdbcOpenSearchSpec" +
+    " org.checkita.dqf.connections.jdbc.GenericJdbcE2ESpec" +
+    " org.checkita.dqf.connections.iceberg.IcebergRestCatalogSpec"
+)
+
 lazy val `checkita-data-quality` = (project in file("."))
   .aggregate(`checkita-core`, `checkita-api`)
   .settings(publish / skip := true)
@@ -17,6 +25,7 @@ lazy val `checkita-core` = (project in file("checkita-core"))
         Utils.getSparkDependencies(sparkVersion.value, assyMode.value).values
     },
     excludeDependencies ++= Utils.getExcludeDependencies(sparkVersion.value),
+    Test / testOptions += Tests.Argument("-l", "IntegrationTest"),
     Compile / doc / target := baseDirectory.value / ".." / "docs/api",
     dependencyOverrides ++= (Utils.overrideFasterXml(sparkVersion.value) :+ Utils.overrideSnakeYaml),
     assembly / assemblyJarName := s"${name.value}_${scalaBinaryVersion.value}-${version.value}-uber.jar",

--- a/checkita-core/src/main/scala/org/checkita/dqf/config/jobconf/Connections.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/config/jobconf/Connections.scala
@@ -225,6 +225,56 @@ object Connections {
                                              ) extends JdbcConnectionConfig
 
   /**
+   * Generic JDBC connection configuration for any JDBC-compatible database.
+   * Allows connecting to databases not explicitly supported by the framework
+   * (e.g. Trino, OpenSearch) by supplying the full JDBC URL and driver class name.
+   *
+   * @param id          Connection Id
+   * @param description Connection description
+   * @param url         Full JDBC URL, e.g. jdbc:trino://host:8080/catalog or jdbc:opensearch://host:9200
+   * @param driver      Fully qualified JDBC driver class name, e.g. io.trino.jdbc.TrinoDriver
+   * @param username    Username used for connection
+   * @param password    Password used for connection
+   * @param schema      Optional schema to lookup tables from. If omitted, default schema is used.
+   * @param parameters  Sequence of additional connection parameters
+   * @param metadata    List of metadata parameters specific to this connection
+   */
+  final case class GenericJdbcConnectionConfig(
+                                                id: ID,
+                                                description: Option[NonEmptyString],
+                                                url: URI,
+                                                driver: NonEmptyString,
+                                                username: Option[NonEmptyString],
+                                                password: Option[NonEmptyString],
+                                                schema: Option[NonEmptyString],
+                                                parameters: Seq[SparkParam] = Seq.empty,
+                                                metadata: Seq[SparkParam] = Seq.empty
+                                              ) extends JdbcConnectionConfig
+
+  /**
+   * Connection configuration for Apache Iceberg tables
+   *
+   * @param id          Connection Id
+   * @param description Connection description
+   * @param catalogName Spark catalog name used to register the Iceberg catalog
+   * @param catalogType Iceberg catalog type: hadoop, hive, rest, glue, nessie
+   * @param warehouse   Warehouse location (path or URI)
+   * @param catalogUri  Catalog service URI (for hive, rest, nessie catalog types)
+   * @param parameters  Sequence of additional catalog parameters
+   * @param metadata    List of metadata parameters specific to this connection
+   */
+  final case class IcebergConnectionConfig(
+                                            id: ID,
+                                            description: Option[NonEmptyString],
+                                            catalogName: NonEmptyString,
+                                            catalogType: NonEmptyString,
+                                            warehouse: Option[URI],
+                                            catalogUri: Option[URI],
+                                            parameters: Seq[SparkParam] = Seq.empty,
+                                            metadata: Seq[SparkParam] = Seq.empty
+                                          ) extends ConnectionConfig
+
+  /**
    * Data Quality job configuration section describing connections to external systems.
    *
    * @param kafka      Sequence of Kafka connections
@@ -236,6 +286,8 @@ object Connections {
    * @param h2         Sequence of H2 connections
    * @param greenplum  Sequence of Greenplum connections
    * @param clickhouse Sequence of ClickHouse connections
+   * @param jdbc       Sequence of generic JDBC connections
+   * @param iceberg    Sequence of Iceberg connections
    */
   final case class ConnectionsConfig(
                                       kafka: Seq[KafkaConnectionConfig] = Seq.empty,
@@ -246,9 +298,11 @@ object Connections {
                                       mssql: Seq[MSSQLConnectionConfig] = Seq.empty,
                                       h2: Seq[H2ConnectionConfig] = Seq.empty,
                                       greenplum: Seq[GreenplumConnectionConfig] = Seq.empty,
-                                      clickhouse: Seq[ClickHouseConnectionConfig] = Seq.empty
+                                      clickhouse: Seq[ClickHouseConnectionConfig] = Seq.empty,
+                                      jdbc: Seq[GenericJdbcConnectionConfig] = Seq.empty,
+                                      iceberg: Seq[IcebergConnectionConfig] = Seq.empty
                                     ) {
-    def getAllConnections: Seq[ConnectionConfig] = 
+    def getAllConnections: Seq[ConnectionConfig] =
       this.productIterator.toSeq.flatMap(_.asInstanceOf[Seq[Any]]).map(_.asInstanceOf[ConnectionConfig])
   }
 }

--- a/checkita-core/src/main/scala/org/checkita/dqf/config/jobconf/Sources.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/config/jobconf/Sources.scala
@@ -179,6 +179,33 @@ object Sources {
   }
 
   /**
+   * Iceberg Table source configuration
+   *
+   * @param id          Source ID
+   * @param description Source description
+   * @param connection  Connection ID (must be Iceberg connection)
+   * @param table       Table name to read
+   * @param database    Database (namespace) within the Iceberg catalog. Defaults to "default".
+   * @param persist     Spark storage level in order to persist dataframe during job execution.
+   * @param options     List of additional spark options required to read the source (if any)
+   * @param keyFields   Sequence of key fields (columns that identify data row)
+   * @param metadata    List of metadata parameters specific to this source
+   */
+  final case class IcebergSourceConfig(
+                                        id: ID,
+                                        description: Option[NonEmptyString],
+                                        connection: ID,
+                                        table: NonEmptyString,
+                                        database: Option[NonEmptyString],
+                                        persist: Option[StorageLevel],
+                                        options: Seq[SparkParam] = Seq.empty,
+                                        keyFields: Seq[NonEmptyString] = Seq.empty,
+                                        metadata: Seq[SparkParam] = Seq.empty
+                                      ) extends SourceConfig {
+    val streamable: Boolean = false
+  }
+
+  /**
    * Base class for file source configurations.
    * All file sources are streamable and therefore must contain windowBy parameter which
    * defined source of timestamp used to build stream windows.
@@ -547,6 +574,7 @@ object Sources {
    * @param hive  Sequence of Hive table sources
    * @param kafka Sequence of sources based on Kafka topics
    * @param greenplum Sequence of greenplum sources (read from pivotal connections)
+   * @param iceberg Sequence of Iceberg table sources
    * @param file  Sequence of file sources
    * @param custom Sequence of custom sources
    */
@@ -555,6 +583,7 @@ object Sources {
                                   hive: Seq[HiveSourceConfig] = Seq.empty,
                                   kafka: Seq[KafkaSourceConfig] = Seq.empty,
                                   greenplum: Seq[GreenplumSourceConfig] = Seq.empty,
+                                  iceberg: Seq[IcebergSourceConfig] = Seq.empty,
                                   file: Seq[FileSourceConfig] = Seq.empty,
                                   custom: Seq[CustomSource] = Seq.empty
                                 ) {

--- a/checkita-core/src/main/scala/org/checkita/dqf/connections/iceberg/IcebergConnection.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/connections/iceberg/IcebergConnection.scala
@@ -1,0 +1,73 @@
+package org.checkita.dqf.connections.iceberg
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.checkita.dqf.appsettings.AppSettings
+import org.checkita.dqf.config.jobconf.Connections.IcebergConnectionConfig
+import org.checkita.dqf.config.jobconf.Sources.IcebergSourceConfig
+import org.checkita.dqf.connections.DQConnection
+import org.checkita.dqf.readers.SchemaReaders.SourceSchema
+import org.checkita.dqf.utils.Common.paramsSeqToMap
+import org.checkita.dqf.utils.ResultUtils._
+
+import scala.util.Try
+
+/**
+ * Connection to Apache Iceberg catalog
+ *
+ * @param config Connection configuration
+ */
+case class IcebergConnection(config: IcebergConnectionConfig) extends DQConnection {
+  type SourceType = IcebergSourceConfig
+
+  val id: String = config.id.value
+  protected val sparkParams: Seq[String] = config.parameters.map(_.value)
+  private val catalogName: String = config.catalogName.value
+  private val catalogType: String = config.catalogType.value
+  private val warehouse: Option[String] = config.warehouse.map(_.value)
+  private val catalogUri: Option[String] = config.catalogUri.map(_.value)
+
+  /**
+   * Checks connection by verifying Iceberg runtime is on the classpath.
+   *
+   * @return Nothing or error message in case if connection is not ready.
+   */
+  def checkConnection: Result[Unit] = Try {
+    Class.forName("org.apache.iceberg.spark.SparkCatalog")
+    ()
+  }.toResult(preMsg = s"Unable to verify Iceberg connection '$id'. " +
+    "Ensure iceberg-spark-runtime JAR is on the classpath. Error: ")
+
+  /**
+   * Configures the Spark session with Iceberg catalog properties.
+   *
+   * @param spark Spark session to configure
+   */
+  private def configureCatalog(implicit spark: SparkSession): Unit = {
+    val prefix = s"spark.sql.catalog.$catalogName"
+    spark.conf.set(prefix, "org.apache.iceberg.spark.SparkCatalog")
+    spark.conf.set(s"$prefix.type", catalogType)
+    warehouse.foreach(w => spark.conf.set(s"$prefix.warehouse", w))
+    catalogUri.foreach(u => spark.conf.set(s"$prefix.uri", u))
+    paramsSeqToMap(sparkParams).foreach { case (k, v) => spark.conf.set(s"$prefix.$k", v) }
+  }
+
+  /**
+   * Loads external data into dataframe given a source configuration
+   *
+   * @param sourceConfig Source configuration
+   * @param settings     Implicit application settings object
+   * @param spark        Implicit spark session object
+   * @param schemas      Implicit Map of all explicitly defined schemas (schemaId -> SourceSchema)
+   * @return Spark DataFrame
+   */
+  def loadDataFrame(sourceConfig: SourceType)
+                   (implicit settings: AppSettings,
+                    spark: SparkSession,
+                    schemas: Map[String, SourceSchema]): DataFrame = {
+    configureCatalog
+    val db = sourceConfig.database.map(_.value).getOrElse("default")
+    val table = sourceConfig.table.value
+    val fqn = s"$catalogName.$db.$table"
+    spark.table(fqn)
+  }
+}

--- a/checkita-core/src/main/scala/org/checkita/dqf/connections/jdbc/GenericJdbcConnection.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/connections/jdbc/GenericJdbcConnection.scala
@@ -1,0 +1,36 @@
+package org.checkita.dqf.connections.jdbc
+
+import org.checkita.dqf.config.jobconf.Connections.GenericJdbcConnectionConfig
+import org.checkita.dqf.utils.ResultUtils._
+
+import java.sql.DriverManager
+import java.util.Properties
+import scala.util.Try
+
+/**
+ * Connection to any JDBC-compatible database
+ *
+ * @param config Connection configuration
+ */
+case class GenericJdbcConnection(config: GenericJdbcConnectionConfig) extends JdbcConnection[GenericJdbcConnectionConfig] {
+  val id: String = config.id.value
+  protected val sparkParams: Seq[String] = config.parameters.map(_.value)
+  protected val connectionUrl: String = config.url.value
+  protected val jdbcDriver: String = config.driver.value
+  protected val currentSchema: Option[String] = config.schema.map(_.value)
+
+  /**
+   * Checks connection with explicit driver class registration.
+   *
+   * @return Nothing or error message in case if connection is not ready.
+   */
+  override def checkConnection: Result[Unit] = Try {
+    Class.forName(jdbcDriver)
+    val connProps = new Properties()
+    config.username.map(_.value).foreach(connProps.put("user", _))
+    config.password.map(_.value).foreach(connProps.put("password", _))
+    val connection = DriverManager.getConnection(connectionUrl, connProps)
+    val isValid = connection.isValid(60)
+    if (!isValid) throw new RuntimeException("Connection invalid")
+  }.toResult(preMsg = s"Unable to establish JDBC connection to following url: $connectionUrl due to following error: ")
+}

--- a/checkita-core/src/main/scala/org/checkita/dqf/readers/ConnectionReaders.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/readers/ConnectionReaders.scala
@@ -2,6 +2,7 @@ package org.checkita.dqf.readers
 
 import org.checkita.dqf.config.jobconf.Connections._
 import org.checkita.dqf.connections.DQConnection
+import org.checkita.dqf.connections.iceberg.IcebergConnection
 import org.checkita.dqf.connections.jdbc._
 import org.checkita.dqf.connections.greenplum.PivotalConnection
 import org.checkita.dqf.connections.kafka.KafkaConnection
@@ -99,6 +100,19 @@ object ConnectionReaders {
     val constructor: ClickHouseConnectionConfig => DQConnection = ClickHouseConnection
   }
 
+  /**
+   * Generic JDBC connection reader: establishes connection to any JDBC-compatible database.
+   */
+  implicit object GenericJdbcConnectionReader extends ConnectionReader[GenericJdbcConnectionConfig] {
+    val constructor: GenericJdbcConnectionConfig => DQConnection = GenericJdbcConnection
+  }
+
+  /**
+   * Iceberg connection reader: establishes connection to Apache Iceberg catalog.
+   */
+  implicit object IcebergConnectionReader extends ConnectionReader[IcebergConnectionConfig] {
+    val constructor: IcebergConnectionConfig => DQConnection = IcebergConnection
+  }
 
   /**
    * General connection reader: invokes connection reader that matches provided connection configuration
@@ -114,6 +128,8 @@ object ConnectionReaders {
       case h2: H2ConnectionConfig => H2Connection(h2)
       case greenplum: GreenplumConnectionConfig => PivotalConnection(greenplum)
       case clickhouse: ClickHouseConnectionConfig => ClickHouseConnection(clickhouse)
+      case jdbc: GenericJdbcConnectionConfig => GenericJdbcConnection(jdbc)
+      case iceberg: IcebergConnectionConfig => IcebergConnection(iceberg)
     }
   }
 

--- a/checkita-core/src/main/scala/org/checkita/dqf/readers/SourceReaders.scala
+++ b/checkita-core/src/main/scala/org/checkita/dqf/readers/SourceReaders.scala
@@ -9,6 +9,7 @@ import org.checkita.dqf.appsettings.AppSettings
 import org.checkita.dqf.config.Enums.StreamWindowing
 import org.checkita.dqf.config.jobconf.Sources._
 import org.checkita.dqf.connections.DQConnection
+import org.checkita.dqf.connections.iceberg.IcebergConnection
 import org.checkita.dqf.connections.jdbc.JdbcConnection
 import org.checkita.dqf.connections.kafka.KafkaConnection
 import org.checkita.dqf.connections.greenplum.PivotalConnection
@@ -289,6 +290,45 @@ object SourceReaders {
         s"Table source '${config.id.value}' refers to not pivotal greenplum connection.")
 
       val df = conn.asInstanceOf[PivotalConnection].loadDataFrame(config)
+      toSource(config, df, readMode)
+    }
+  }
+
+  /**
+   * Iceberg source reader: reads table from Iceberg catalog
+   *
+   * @note In order to read iceberg source it is required to provided map of valid connections
+   */
+  implicit object IcebergSourceReader extends SourceReader[IcebergSourceConfig] {
+
+    /**
+     * Tries to read iceberg source given the source configuration.
+     *
+     * @param config      Iceberg source configuration
+     * @param readMode    Mode in which source is read. Either 'batch' or 'stream'
+     * @param settings    Implicit application settings object
+     * @param spark       Implicit spark session object
+     * @param schemas     Map of explicitly defined schemas (schemaId -> SourceSchema)
+     * @param connections Map of existing connection (connectionID -> DQConnection)
+     * @param checkpoints Map of initial checkpoints read from checkpoint directory
+     * @return Source
+     */
+    def tryToRead(config: IcebergSourceConfig,
+                  readMode: ReadMode)(implicit settings: AppSettings,
+                                      spark: SparkSession,
+                                      fs: FileSystem,
+                                      schemas: Map[String, SourceSchema],
+                                      connections: Map[String, DQConnection],
+                                      checkpoints: Map[String, Checkpoint]): Source = {
+
+      val conn = connections.getOrElse(config.connection.value, throw new NoSuchElementException(
+        s"Iceberg connection with id = '${config.connection.value}' not found."
+      ))
+
+      require(conn.isInstanceOf[IcebergConnection],
+        s"Iceberg source '${config.id.value}' refers to non-Iceberg connection.")
+
+      val df = conn.asInstanceOf[IcebergConnection].loadDataFrame(config)
       toSource(config, df, readMode)
     }
   }
@@ -649,6 +689,7 @@ object SourceReaders {
       case table: TableSourceConfig => TableSourceReader.tryToRead(table, readMode)
       case kafka: KafkaSourceConfig => KafkaSourceReader.tryToRead(kafka, readMode)
       case greenplum: GreenplumSourceConfig => GreenplumSourceReader.tryToRead(greenplum, readMode)
+      case iceberg: IcebergSourceConfig => IcebergSourceReader.tryToRead(iceberg, readMode)
       case hive: HiveSourceConfig => HiveSourceReader.tryToRead(hive, readMode)
       case fixed: FixedFileSourceConfig => FixedFileSourceReader.tryToRead(fixed, readMode)
       case delimited: DelimitedFileSourceConfig => DelimitedFileSourceReader.tryToRead(delimited, readMode)

--- a/checkita-core/src/test/resources/test_job.conf
+++ b/checkita-core/src/test/resources/test_job.conf
@@ -15,6 +15,39 @@ jobConfig: {
     kafka: [
       {id: "kafka_broker", servers: ["server1:9092", "server2:9092"]}
     ]
+    jdbc: [
+      {
+        id: "trino_conn",
+        url: "jdbc:trino://trino-host:8080/hive/default",
+        driver: "io.trino.jdbc.TrinoDriver",
+        username: "dq-user"
+      },
+      {
+        id: "opensearch_conn",
+        url: "jdbc:opensearch://os-host:9200",
+        driver: "org.opensearch.jdbc.Driver",
+        username: "admin",
+        password: "secret",
+        schema: "my_index",
+        parameters: ["fetchSize=1000"]
+      }
+    ]
+    iceberg: [
+      {
+        id: "iceberg_hadoop",
+        catalogName: "test_catalog",
+        catalogType: "hadoop",
+        warehouse: "/tmp/iceberg/warehouse"
+      },
+      {
+        id: "iceberg_hive",
+        catalogName: "hive_catalog",
+        catalogType: "hive",
+        warehouse: "s3a://bucket/warehouse",
+        catalogUri: "thrift://metastore:9083",
+        parameters: ["io-impl=org.apache.iceberg.aws.s3.S3FileIO"]
+      }
+    ]
   }
 
   schemas: [
@@ -53,6 +86,10 @@ jobConfig: {
         partitions: [{name: "dlk_cob_date", values: ["2023-06-30", "2023-07-01"]}],
         keyFields: ["id", "name"]
       }
+    ]
+    iceberg: [
+      {id: "iceberg_source_1", connection: "iceberg_hadoop", table: "events", database: "analytics", keyFields: ["event_id"]}
+      {id: "iceberg_source_2", connection: "iceberg_hive", table: "users"}
     ]
     file: [
       {id: "hdfs_avro_source", kind: "avro", path: "path/to/avro/file.avro", schema: "avro_schema"},

--- a/checkita-core/src/test/scala/org/checkita/dqf/config/IOSpec.scala
+++ b/checkita-core/src/test/scala/org/checkita/dqf/config/IOSpec.scala
@@ -6,17 +6,84 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.checkita.dqf.config.IO.{readEncryptedJobConfig, readJobConfig, writeEncryptedJobConfig, writeJobConfig}
 import org.checkita.dqf.config.Parsers.StringConfigParser
+import org.checkita.dqf.config.jobconf.Connections.{GenericJdbcConnectionConfig, IcebergConnectionConfig}
 
 import java.io.File
 
 class IOSpec extends AnyWordSpec with Matchers {
-  
+
   "Job Configuration" must {
     "be successfully read" in {
       val configFile = new File(getClass.getResource("/test_job.conf").getPath)
       val written = readJobConfig[File](configFile).flatMap(config => writeJobConfig(config)).map(_ => "Success")
 
       written shouldEqual Right("Success")
+    }
+
+    "parse GenericJdbcConnectionConfig fields correctly" in {
+      val configFile = new File(getClass.getResource("/test_job.conf").getPath)
+      val jobConfig = readJobConfig[File](configFile).toOption.get
+
+      val jdbcConns = jobConfig.connections.map(_.jdbc).getOrElse(Seq.empty)
+      jdbcConns should have size 2
+
+      val trino = jdbcConns.find(_.id.value == "trino_conn").get
+      trino.url.value          shouldEqual "jdbc:trino://trino-host:8080/hive/default"
+      trino.driver.value       shouldEqual "io.trino.jdbc.TrinoDriver"
+      trino.username.map(_.value) shouldEqual Some("dq-user")
+      trino.password           shouldBe None
+      trino.schema             shouldBe None
+
+      val os = jdbcConns.find(_.id.value == "opensearch_conn").get
+      os.url.value             shouldEqual "jdbc:opensearch://os-host:9200"
+      os.driver.value          shouldEqual "org.opensearch.jdbc.Driver"
+      os.username.map(_.value) shouldEqual Some("admin")
+      os.password.map(_.value) shouldEqual Some("secret")
+      os.schema.map(_.value)   shouldEqual Some("my_index")
+      os.parameters            should have size 1
+      os.parameters.head.value shouldEqual "fetchSize=1000"
+    }
+
+    "parse IcebergConnectionConfig fields correctly" in {
+      val configFile = new File(getClass.getResource("/test_job.conf").getPath)
+      val jobConfig = readJobConfig[File](configFile).toOption.get
+
+      val icebergConns = jobConfig.connections.map(_.iceberg).getOrElse(Seq.empty)
+      icebergConns should have size 2
+
+      val hadoop = icebergConns.find(_.id.value == "iceberg_hadoop").get
+      hadoop.catalogName.value    shouldEqual "test_catalog"
+      hadoop.catalogType.value    shouldEqual "hadoop"
+      hadoop.warehouse.map(_.value) shouldEqual Some("/tmp/iceberg/warehouse")
+      hadoop.catalogUri           shouldBe None
+      hadoop.parameters           shouldBe empty
+
+      val hive = icebergConns.find(_.id.value == "iceberg_hive").get
+      hive.catalogName.value    shouldEqual "hive_catalog"
+      hive.catalogType.value    shouldEqual "hive"
+      hive.warehouse.map(_.value) shouldEqual Some("s3a://bucket/warehouse")
+      hive.catalogUri.map(_.value) shouldEqual Some("thrift://metastore:9083")
+      hive.parameters            should have size 1
+      hive.parameters.head.value shouldEqual "io-impl=org.apache.iceberg.aws.s3.S3FileIO"
+    }
+
+    "parse IcebergSourceConfig fields correctly" in {
+      val configFile = new File(getClass.getResource("/test_job.conf").getPath)
+      val jobConfig = readJobConfig[File](configFile).toOption.get
+
+      val icebergSources = jobConfig.sources.map(_.iceberg).getOrElse(Seq.empty)
+      icebergSources should have size 2
+
+      val src1 = icebergSources.find(_.id.value == "iceberg_source_1").get
+      src1.connection.value   shouldEqual "iceberg_hadoop"
+      src1.table.value        shouldEqual "events"
+      src1.database.map(_.value) shouldEqual Some("analytics")
+      src1.keyFields.map(_.value) shouldEqual Seq("event_id")
+
+      val src2 = icebergSources.find(_.id.value == "iceberg_source_2").get
+      src2.connection.value   shouldEqual "iceberg_hive"
+      src2.table.value        shouldEqual "users"
+      src2.database           shouldBe None
     }
 
     "be decrypted successfully" in {

--- a/checkita-core/src/test/scala/org/checkita/dqf/connections/IntegrationTestTag.scala
+++ b/checkita-core/src/test/scala/org/checkita/dqf/connections/IntegrationTestTag.scala
@@ -1,0 +1,10 @@
+package org.checkita.dqf.connections
+
+import org.scalatest.Tag
+
+/**
+ * Tag for integration tests that require a running container runtime (Docker/Podman).
+ * These tests are excluded from the default `sbt test` run and can be executed with:
+ *   sbt "testOnly * -- -n IntegrationTest"
+ */
+object IntegrationTestTag extends Tag("IntegrationTest")

--- a/checkita-core/src/test/scala/org/checkita/dqf/connections/iceberg/IcebergConnectionSpec.scala
+++ b/checkita-core/src/test/scala/org/checkita/dqf/connections/iceberg/IcebergConnectionSpec.scala
@@ -1,0 +1,119 @@
+package org.checkita.dqf.connections.iceberg
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.types.string.NonEmptyString
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.checkita.dqf.Common._
+import org.checkita.dqf.config.RefinedTypes.ID
+import org.checkita.dqf.config.jobconf.Connections.IcebergConnectionConfig
+import org.checkita.dqf.config.jobconf.Sources.IcebergSourceConfig
+import org.checkita.dqf.readers.ConnectionReaders._
+import org.checkita.dqf.readers.SchemaReaders.SourceSchema
+
+import java.nio.file.Files
+
+class IcebergConnectionSpec extends AnyWordSpec with Matchers {
+
+  private val warehousePath = Files.createTempDirectory("iceberg_test_warehouse").toAbsolutePath.toString
+
+  private val validConfig = IcebergConnectionConfig(
+    id          = ID("iceberg_test"),
+    description = None,
+    catalogName = NonEmptyString.unsafeFrom("test_catalog"),
+    catalogType = NonEmptyString.unsafeFrom("hadoop"),
+    warehouse   = Some(Refined.unsafeApply(warehousePath)),
+    catalogUri  = None
+  )
+
+  implicit val schemas: Map[String, SourceSchema] = Map.empty
+
+  private def icebergSource(connId: String,
+                            table: String,
+                            database: Option[String] = None): IcebergSourceConfig =
+    IcebergSourceConfig(
+      id          = ID("test_iceberg_source"),
+      description = None,
+      connection  = ID(connId),
+      table       = NonEmptyString.unsafeFrom(table),
+      database    = database.map(NonEmptyString.unsafeFrom),
+      persist     = None
+    )
+
+  "IcebergConnection" must {
+
+    "be instantiated with correct id from config" in {
+      val conn = IcebergConnection(validConfig)
+      conn.id shouldEqual "iceberg_test"
+    }
+
+    "pass connection check when Iceberg runtime is on classpath" in {
+      val result = validConfig.read
+      result.isRight shouldEqual true
+    }
+
+    "create and read an Iceberg table using Hadoop catalog" in {
+      val conn = IcebergConnection(validConfig)
+
+      // Create table and insert data via Spark SQL
+      val catalogName = "test_catalog"
+      spark.conf.set(s"spark.sql.catalog.$catalogName", "org.apache.iceberg.spark.SparkCatalog")
+      spark.conf.set(s"spark.sql.catalog.$catalogName.type", "hadoop")
+      spark.conf.set(s"spark.sql.catalog.$catalogName.warehouse", warehousePath)
+
+      spark.sql(s"CREATE DATABASE IF NOT EXISTS $catalogName.test_db")
+      spark.sql(
+        s"""CREATE TABLE IF NOT EXISTS $catalogName.test_db.companies (
+           |  id INT,
+           |  name STRING,
+           |  revenue DOUBLE
+           |) USING iceberg""".stripMargin
+      )
+      spark.sql(
+        s"""INSERT INTO $catalogName.test_db.companies VALUES
+           |(1, 'Foo Corp', 100.5),
+           |(2, 'Bar Ltd', 200.0),
+           |(3, 'Baz Inc', 300.75)""".stripMargin
+      )
+
+      val df = conn.loadDataFrame(icebergSource("iceberg_test", "companies", Some("test_db")))
+      df.count() shouldEqual 3
+      df.columns.map(_.toLowerCase) should contain allOf("id", "name", "revenue")
+    }
+
+    "use default database when database is not specified" in {
+      val conn = IcebergConnection(validConfig)
+      val catalogName = "test_catalog"
+
+      spark.sql(
+        s"""CREATE TABLE IF NOT EXISTS $catalogName.default.default_table (
+           |  id INT,
+           |  value STRING
+           |) USING iceberg""".stripMargin
+      )
+      spark.sql(s"INSERT INTO $catalogName.default.default_table VALUES (1, 'test')")
+
+      val df = conn.loadDataFrame(icebergSource("iceberg_test", "default_table"))
+      df.count() shouldEqual 1
+    }
+
+    "handle NULL values correctly" in {
+      val conn = IcebergConnection(validConfig)
+      val catalogName = "test_catalog"
+
+      spark.sql(
+        s"""CREATE TABLE IF NOT EXISTS $catalogName.test_db.nullable_table (
+           |  id INT,
+           |  name STRING
+           |) USING iceberg""".stripMargin
+      )
+      spark.sql(s"INSERT INTO $catalogName.test_db.nullable_table VALUES (1, 'hello'), (2, NULL)")
+
+      val df = conn.loadDataFrame(icebergSource("iceberg_test", "nullable_table", Some("test_db")))
+      df.count() shouldEqual 2
+
+      val nullRow = df.filter("id = 2").select("name").collect().head
+      nullRow.isNullAt(0) shouldEqual true
+    }
+  }
+}

--- a/checkita-core/src/test/scala/org/checkita/dqf/connections/iceberg/IcebergRestCatalogSpec.scala
+++ b/checkita-core/src/test/scala/org/checkita/dqf/connections/iceberg/IcebergRestCatalogSpec.scala
@@ -1,0 +1,182 @@
+package org.checkita.dqf.connections.iceberg
+
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.types.string.NonEmptyString
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.checkita.dqf.Common._
+import org.checkita.dqf.config.RefinedTypes.ID
+import org.checkita.dqf.config.jobconf.Connections.IcebergConnectionConfig
+import org.checkita.dqf.config.jobconf.Sources.IcebergSourceConfig
+import org.checkita.dqf.connections.IntegrationTestTag
+import org.checkita.dqf.readers.ConnectionReaders._
+import org.checkita.dqf.readers.SchemaReaders.SourceSchema
+import org.testcontainers.containers.wait.strategy.Wait
+
+import java.nio.file.Files
+import java.time.Duration
+
+/**
+ * Integration test for IcebergConnection with REST catalog.
+ * Requires a running container runtime (Docker/Podman).
+ */
+class IcebergRestCatalogSpec extends AnyWordSpec with Matchers with ForAllTestContainer {
+
+  private val warehousePath = Files.createTempDirectory("iceberg_rest_warehouse").toAbsolutePath.toString
+  private val catalogName = "rest_it_catalog"
+
+  override val container: GenericContainer = GenericContainer(
+    dockerImage = "tabulario/iceberg-rest:0.13.0",
+    exposedPorts = Seq(8181),
+    env = Map(
+      "CATALOG_WAREHOUSE" -> "file:///tmp/warehouse",
+      "CATALOG_IO__IMPL" -> "org.apache.iceberg.io.ResolvingFileIO"
+    ),
+    waitStrategy = Wait.forHttp("/v1/config")
+      .forPort(8181)
+      .forStatusCode(200)
+      .withStartupTimeout(Duration.ofSeconds(60))
+  )
+
+  implicit val schemas: Map[String, SourceSchema] = Map.empty
+
+  private def restUri: String = s"http://localhost:${container.mappedPort(8181)}"
+
+  private def validConfig: IcebergConnectionConfig = IcebergConnectionConfig(
+    id          = ID("iceberg_rest"),
+    description = None,
+    catalogName = NonEmptyString.unsafeFrom(catalogName),
+    catalogType = NonEmptyString.unsafeFrom("rest"),
+    warehouse   = Some(Refined.unsafeApply(warehousePath)),
+    catalogUri  = Some(Refined.unsafeApply(restUri))
+  )
+
+  private def icebergSource(table: String, database: Option[String] = None): IcebergSourceConfig =
+    IcebergSourceConfig(
+      id          = ID("it_source"),
+      description = None,
+      connection  = ID("iceberg_rest"),
+      table       = NonEmptyString.unsafeFrom(table),
+      database    = database.map(NonEmptyString.unsafeFrom),
+      persist     = None
+    )
+
+  private def setupCatalog(): Unit = {
+    spark.conf.set(s"spark.sql.catalog.$catalogName", "org.apache.iceberg.spark.SparkCatalog")
+    spark.conf.set(s"spark.sql.catalog.$catalogName.type", "rest")
+    spark.conf.set(s"spark.sql.catalog.$catalogName.uri", restUri)
+    spark.conf.set(s"spark.sql.catalog.$catalogName.warehouse", warehousePath)
+  }
+
+  "IcebergConnection with REST catalog" must {
+
+    "pass checkConnection when Iceberg runtime is on classpath" taggedAs IntegrationTestTag in {
+      val result = validConfig.read
+      result.isRight shouldEqual true
+    }
+
+    "connect to REST catalog and create/read tables" taggedAs IntegrationTestTag in {
+      setupCatalog()
+
+      spark.sql(s"CREATE NAMESPACE IF NOT EXISTS $catalogName.test_ns")
+      spark.sql(
+        s"""CREATE TABLE IF NOT EXISTS $catalogName.test_ns.events (
+           |  event_id INT,
+           |  event_type STRING,
+           |  payload STRING
+           |) USING iceberg""".stripMargin
+      )
+      spark.sql(
+        s"""INSERT INTO $catalogName.test_ns.events VALUES
+           |(1, 'click', '{"page": "/home"}'),
+           |(2, 'view', '{"page": "/about"}'),
+           |(3, 'click', '{"page": "/products"}')""".stripMargin
+      )
+
+      val conn = IcebergConnection(validConfig)
+      val df = conn.loadDataFrame(icebergSource("events", Some("test_ns")))
+      df.count() shouldEqual 3
+      df.columns.map(_.toLowerCase) should contain allOf("event_id", "event_type", "payload")
+    }
+
+    "read from default namespace" taggedAs IntegrationTestTag in {
+      spark.sql(
+        s"""CREATE TABLE IF NOT EXISTS $catalogName.default.metrics (
+           |  metric_name STRING,
+           |  metric_value DOUBLE
+           |) USING iceberg""".stripMargin
+      )
+      spark.sql(
+        s"""INSERT INTO $catalogName.default.metrics VALUES
+           |('cpu_usage', 75.5),
+           |('mem_usage', 82.3)""".stripMargin
+      )
+
+      val conn = IcebergConnection(validConfig)
+      val df = conn.loadDataFrame(icebergSource("metrics"))
+      df.count() shouldEqual 2
+    }
+
+    "handle various data types including timestamps and decimals" taggedAs IntegrationTestTag in {
+      spark.sql(
+        s"""CREATE TABLE IF NOT EXISTS $catalogName.test_ns.typed_table (
+           |  id INT,
+           |  name STRING,
+           |  active BOOLEAN,
+           |  score DOUBLE,
+           |  amount DECIMAL(10,2),
+           |  created_at TIMESTAMP,
+           |  event_date DATE
+           |) USING iceberg""".stripMargin
+      )
+      spark.sql(
+        s"""INSERT INTO $catalogName.test_ns.typed_table VALUES
+           |(1, 'Alice', true, 95.5, 1234.56, TIMESTAMP '2024-01-15 10:30:00', DATE '2024-01-15'),
+           |(2, 'Bob', false, 42.0, 789.00, TIMESTAMP '2024-06-20 14:00:00', DATE '2024-06-20')""".stripMargin
+      )
+
+      val conn = IcebergConnection(validConfig)
+      val df = conn.loadDataFrame(icebergSource("typed_table", Some("test_ns")))
+
+      df.count() shouldEqual 2
+      df.columns.map(_.toLowerCase) should contain allOf(
+        "id", "name", "active", "score", "amount", "created_at", "event_date"
+      )
+
+      val row1 = df.filter("id = 1").collect().head
+      row1.getAs[Boolean]("active") shouldEqual true
+    }
+
+    "handle NULL values correctly" taggedAs IntegrationTestTag in {
+      spark.sql(
+        s"""CREATE TABLE IF NOT EXISTS $catalogName.test_ns.nullable_table (
+           |  id INT,
+           |  optional_field STRING
+           |) USING iceberg""".stripMargin
+      )
+      spark.sql(
+        s"""INSERT INTO $catalogName.test_ns.nullable_table VALUES
+           |(1, 'present'),
+           |(2, NULL)""".stripMargin
+      )
+
+      val conn = IcebergConnection(validConfig)
+      val df = conn.loadDataFrame(icebergSource("nullable_table", Some("test_ns")))
+      df.count() shouldEqual 2
+
+      val nullRow = df.filter("id = 2").select("optional_field").collect().head
+      nullRow.isNullAt(0) shouldEqual true
+
+      val nonNullRow = df.filter("id = 1").select("optional_field").collect().head
+      nonNullRow.getString(0) shouldEqual "present"
+    }
+
+    "fail to read a non-existent table" taggedAs IntegrationTestTag in {
+      val conn = IcebergConnection(validConfig)
+      an[Exception] should be thrownBy {
+        conn.loadDataFrame(icebergSource("nonexistent_table_xyz", Some("test_ns")))
+      }
+    }
+  }
+}

--- a/checkita-core/src/test/scala/org/checkita/dqf/connections/jdbc/GenericJdbcConnectionSpec.scala
+++ b/checkita-core/src/test/scala/org/checkita/dqf/connections/jdbc/GenericJdbcConnectionSpec.scala
@@ -1,0 +1,215 @@
+package org.checkita.dqf.connections.jdbc
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.types.string.NonEmptyString
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.checkita.dqf.Common._
+import org.checkita.dqf.config.RefinedTypes.ID
+import org.checkita.dqf.config.jobconf.Connections.GenericJdbcConnectionConfig
+import org.checkita.dqf.config.jobconf.Sources.TableSourceConfig
+import org.checkita.dqf.readers.ConnectionReaders._
+import org.checkita.dqf.readers.SchemaReaders.SourceSchema
+
+import java.sql.DriverManager
+
+class GenericJdbcConnectionSpec extends AnyWordSpec with Matchers {
+
+  private val h2Driver = "org.h2.Driver"
+  private val h2Url    = "jdbc:h2:mem:generic_jdbc_test"
+
+  // Keep an open connection so the in-memory H2 DB stays alive for all tests
+  private val setupConn = {
+    Class.forName(h2Driver)
+    val c = DriverManager.getConnection(h2Url)
+    val stmt = c.createStatement()
+    stmt.execute(
+      """CREATE TABLE IF NOT EXISTS test_companies (
+        |  id INT,
+        |  name VARCHAR(100),
+        |  revenue DOUBLE,
+        |  is_active BOOLEAN,
+        |  founded DATE,
+        |  created_at TIMESTAMP,
+        |  rating DECIMAL(5,2),
+        |  description VARCHAR(200)
+        |)""".stripMargin
+    )
+    stmt.execute(
+      "INSERT INTO test_companies SELECT 1, 'Foo Corp', 100.5, TRUE, '2020-01-15', '2020-01-15 10:30:00', 4.50, 'First company' " +
+        "WHERE NOT EXISTS (SELECT 1 FROM test_companies WHERE id = 1)"
+    )
+    stmt.execute(
+      "INSERT INTO test_companies SELECT 2, 'Bar Ltd', 200.0, FALSE, '2019-06-20', '2019-06-20 14:00:00', 3.75, NULL " +
+        "WHERE NOT EXISTS (SELECT 1 FROM test_companies WHERE id = 2)"
+    )
+    stmt.execute(
+      "INSERT INTO test_companies SELECT 3, 'Baz Inc', 300.75, TRUE, '2021-03-10', '2021-03-10 09:15:00', 4.95, 'Third company' " +
+        "WHERE NOT EXISTS (SELECT 1 FROM test_companies WHERE id = 3)"
+    )
+    c
+  }
+
+  private val validConfig = GenericJdbcConnectionConfig(
+    id          = ID("h2_generic"),
+    description = None,
+    url         = Refined.unsafeApply(h2Url),
+    driver      = NonEmptyString.unsafeFrom(h2Driver),
+    username    = None,
+    password    = None,
+    schema      = None
+  )
+
+  private val h2AuthUrl = "jdbc:h2:mem:generic_jdbc_auth_test"
+  private val authSetupConn = {
+    val c = DriverManager.getConnection(h2AuthUrl, "testuser", "testpass")
+    val stmt = c.createStatement()
+    stmt.execute("CREATE TABLE IF NOT EXISTS auth_table (id INT, name VARCHAR(50))")
+    stmt.execute("INSERT INTO auth_table SELECT 1, 'auth_test' WHERE NOT EXISTS (SELECT 1 FROM auth_table WHERE id = 1)")
+    c
+  }
+
+  private val configWithAuth = GenericJdbcConnectionConfig(
+    id          = ID("h2_with_auth"),
+    description = None,
+    url         = Refined.unsafeApply(h2AuthUrl),
+    driver      = NonEmptyString.unsafeFrom(h2Driver),
+    username    = Some(NonEmptyString.unsafeFrom("testuser")),
+    password    = Some(NonEmptyString.unsafeFrom("testpass")),
+    schema      = None
+  )
+
+  implicit val schemas: Map[String, SourceSchema] = Map.empty
+
+  private def tableSource(connId: String,
+                          table: Option[String] = None,
+                          query: Option[String] = None): TableSourceConfig =
+    TableSourceConfig(
+      id          = ID("test_source"),
+      description = None,
+      connection  = ID(connId),
+      table       = table.map(NonEmptyString.unsafeFrom),
+      query       = query.map(NonEmptyString.unsafeFrom),
+      persist     = None
+    )
+
+  "GenericJdbcConnection" must {
+
+    "be instantiated with correct id from config" in {
+      val conn = GenericJdbcConnection(validConfig)
+      conn.id shouldEqual "h2_generic"
+    }
+
+    "pass connection check when database is available" in {
+      val result = validConfig.read
+      result.isRight shouldEqual true
+    }
+
+    "pass connection check with username and password" in {
+      val result = configWithAuth.read
+      result.isRight shouldEqual true
+    }
+
+    "fail connection check when driver class is not found" in {
+      val badDriver = validConfig.copy(
+        id     = ID("bad_driver"),
+        driver = NonEmptyString.unsafeFrom("com.nonexistent.Driver")
+      )
+      badDriver.read.isLeft shouldEqual true
+    }
+
+    "fail connection check when URL is not handled by any registered driver" in {
+      val badConfig = validConfig.copy(
+        id  = ID("bad_conn"),
+        url = Refined.unsafeApply("jdbc:unknowndb://nonexistent-host:9999/db")
+      )
+      badConfig.read.isLeft shouldEqual true
+    }
+
+    "load data from a table" in {
+      val conn = GenericJdbcConnection(validConfig)
+      val df = conn.loadDataFrame(tableSource("h2_generic", table = Some("test_companies")))
+      df.count() shouldEqual 3
+      df.columns.map(_.toLowerCase) should contain allOf("id", "name", "revenue")
+    }
+
+    "load data using an arbitrary SQL query" in {
+      val conn = GenericJdbcConnection(validConfig)
+      val df = conn.loadDataFrame(tableSource(
+        "h2_generic",
+        query = Some("SELECT * FROM test_companies WHERE revenue > 150")
+      ))
+      df.count() shouldEqual 2
+    }
+
+    "throw an exception when both table and query are provided" in {
+      val conn = GenericJdbcConnection(validConfig)
+      an[IllegalArgumentException] should be thrownBy {
+        conn.loadDataFrame(tableSource(
+          "h2_generic",
+          table = Some("test_companies"),
+          query = Some("SELECT 1")
+        ))
+      }
+    }
+
+    "throw an exception when neither table nor query is provided" in {
+      val conn = GenericJdbcConnection(validConfig)
+      an[IllegalArgumentException] should be thrownBy {
+        conn.loadDataFrame(tableSource("h2_generic"))
+      }
+    }
+
+    "apply schema prefix to table name when schema is configured" in {
+      val conn = DriverManager.getConnection(h2Url)
+      conn.createStatement().execute("CREATE SCHEMA IF NOT EXISTS myschema")
+      conn.createStatement().execute(
+        "CREATE TABLE IF NOT EXISTS myschema.prefixed_table (id INT, val VARCHAR(10))"
+      )
+      conn.createStatement().execute(
+        "INSERT INTO myschema.prefixed_table SELECT 42, 'hello' " +
+          "WHERE NOT EXISTS (SELECT 1 FROM myschema.prefixed_table WHERE id = 42)"
+      )
+      conn.close()
+
+      val configWithSchema = validConfig.copy(
+        id     = ID("h2_with_schema"),
+        schema = Some(NonEmptyString.unsafeFrom("myschema"))
+      )
+      val jdbcConn = GenericJdbcConnection(configWithSchema)
+      val df = jdbcConn.loadDataFrame(tableSource(
+        "h2_with_schema",
+        table = Some("prefixed_table")
+      ))
+      df.count() shouldEqual 1
+    }
+
+    "preserve various data types including NULL values" in {
+      val conn = GenericJdbcConnection(validConfig)
+      val df = conn.loadDataFrame(tableSource("h2_generic", table = Some("test_companies")))
+
+      df.columns.map(_.toLowerCase) should contain allOf(
+        "id", "name", "revenue", "is_active", "founded", "created_at", "rating", "description"
+      )
+
+      // Row with id=2 has NULL description
+      val nullRow = df.filter("id = 2").select("description").collect().head
+      nullRow.isNullAt(0) shouldEqual true
+
+      // Non-null values are preserved
+      val row1 = df.filter("id = 1").collect().head
+      row1.getAs[Boolean]("IS_ACTIVE") shouldEqual true
+    }
+
+    "pass spark parameters through to JDBC options" in {
+      val configWithParams = validConfig.copy(
+        id         = ID("h2_with_params"),
+        parameters = Seq(Refined.unsafeApply("fetchsize=10"))
+      )
+      val conn = GenericJdbcConnection(configWithParams)
+      // If parameters caused an error, loadDataFrame would fail
+      val df = conn.loadDataFrame(tableSource("h2_with_params", table = Some("test_companies")))
+      df.count() shouldEqual 3
+    }
+  }
+}

--- a/checkita-core/src/test/scala/org/checkita/dqf/connections/jdbc/GenericJdbcE2ESpec.scala
+++ b/checkita-core/src/test/scala/org/checkita/dqf/connections/jdbc/GenericJdbcE2ESpec.scala
@@ -1,0 +1,225 @@
+package org.checkita.dqf.connections.jdbc
+
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import org.apache.logging.log4j.Level
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.checkita.dqf.config.IO.readJobConfig
+import org.checkita.dqf.connections.IntegrationTestTag
+import org.checkita.dqf.context.DQContext
+import org.testcontainers.containers.wait.strategy.Wait
+
+import java.io.{File, PrintWriter}
+import java.nio.file.Files
+import java.sql.DriverManager
+import java.time.Duration
+
+/**
+ * End-to-end integration test: runs a full Checkita DQ pipeline
+ * (connection → source → metrics → checks) against a real PostgreSQL database.
+ * Requires a running container runtime (Docker/Podman).
+ */
+class GenericJdbcE2ESpec extends AnyWordSpec with Matchers with ForAllTestContainer {
+
+  override val container: GenericContainer = GenericContainer(
+    dockerImage = "postgres:15",
+    exposedPorts = Seq(5432),
+    env = Map(
+      "POSTGRES_DB" -> "dq_e2e",
+      "POSTGRES_USER" -> "dq_user",
+      "POSTGRES_PASSWORD" -> "dq_pass"
+    ),
+    waitStrategy = Wait.forLogMessage(".*database system is ready to accept connections.*", 2)
+      .withStartupTimeout(Duration.ofSeconds(60))
+  )
+
+  private def pgPort: Int = container.mappedPort(5432)
+
+  private def seedData(): Unit = {
+    val conn = DriverManager.getConnection(
+      s"jdbc:postgresql://localhost:$pgPort/dq_e2e", "dq_user", "dq_pass"
+    )
+    val stmt = conn.createStatement()
+    stmt.execute(
+      """CREATE TABLE IF NOT EXISTS sales (
+        |  id SERIAL PRIMARY KEY,
+        |  product VARCHAR(50),
+        |  region VARCHAR(30),
+        |  amount NUMERIC(10,2),
+        |  category VARCHAR(30)
+        |)""".stripMargin
+    )
+    stmt.execute("DELETE FROM sales")
+    stmt.execute(
+      """INSERT INTO sales (product, region, amount, category) VALUES
+        |  ('Widget A', 'North', 150.00, 'Electronics'),
+        |  ('Widget B', 'South', 230.50, 'Electronics'),
+        |  ('Gadget C', 'North', NULL,    'Gadgets'),
+        |  ('Widget A', 'East',  89.99,  'Electronics'),
+        |  ('Gadget D', 'South', 445.00, NULL),
+        |  ('Widget B', 'West',  175.25, 'Electronics'),
+        |  ('Gadget C', 'North', 320.00, 'Gadgets'),
+        |  ('Widget A', 'South', 210.00, 'Electronics'),
+        |  ('Gadget D', 'East',  NULL,    'Gadgets'),
+        |  ('Widget B', 'North', 190.75, 'Electronics')""".stripMargin
+    )
+    stmt.close()
+    conn.close()
+  }
+
+  private def jobConfigString: String =
+    s"""
+    jobConfig: {
+      jobId: "e2e_test_job"
+      connections: {
+        postgres: [{
+          id: "pg_e2e"
+          url: "localhost:$pgPort/dq_e2e"
+          username: "dq_user"
+          password: "dq_pass"
+          schema: "public"
+        }]
+      }
+      sources: {
+        table: [{
+          id: "sales"
+          connection: "pg_e2e"
+          table: "sales"
+          keyFields: ["id"]
+        }]
+      }
+      metrics: {
+        regular: {
+          rowCount: [
+            {id: "sales_row_cnt", source: "sales"}
+          ]
+          nullValues: [
+            {id: "sales_amount_nulls", source: "sales", columns: ["amount"]}
+            {id: "sales_category_nulls", source: "sales", columns: ["category"]}
+          ]
+          completeness: [
+            {id: "sales_amount_completeness", source: "sales", columns: ["amount"]}
+          ]
+          distinctValues: [
+            {id: "sales_distinct_products", source: "sales", columns: ["product"]}
+            {id: "sales_distinct_regions", source: "sales", columns: ["region"]}
+          ]
+        }
+      }
+      checks: {
+        snapshot: {
+          greaterThan: [
+            {id: "has_rows", metric: "sales_row_cnt", threshold: 0}
+            {id: "completeness_above_70pct", metric: "sales_amount_completeness", threshold: 0.7}
+          ]
+          lessThan: [
+            {id: "amount_nulls_below_5", metric: "sales_amount_nulls", threshold: 5}
+          ]
+          equalTo: [
+            {id: "exactly_4_products", metric: "sales_distinct_products", threshold: 4}
+            {id: "exactly_4_regions", metric: "sales_distinct_regions", threshold: 4}
+          ]
+        }
+      }
+    }
+    """
+
+  private val appConfigString: String =
+    """
+    appConfig: {
+      applicationName: "E2E Test"
+      dateTimeOptions: {
+        timeZone: "UTC"
+        referenceDateFormat: "yyyy-MM-dd"
+        executionDateFormat: "yyyy-MM-dd HH:mm:ss"
+      }
+      enablers: {
+        allowSqlQueries: true
+      }
+      defaultSparkOptions: [
+        "spark.driver.host=localhost"
+        "spark.sql.shuffle.partitions=4"
+      ]
+    }
+    """
+
+  private def writeToTempFile(content: String, prefix: String): String = {
+    val file = Files.createTempFile(prefix, ".conf").toFile
+    val pw = new PrintWriter(file)
+    pw.write(content)
+    pw.close()
+    file.getAbsolutePath
+  }
+
+  "Full Checkita DQ pipeline with PostgreSQL" must {
+
+    "calculate metrics and run checks correctly" taggedAs IntegrationTestTag in {
+      seedData()
+
+      val appConfigPath = writeToTempFile(appConfigString, "app_config_")
+      val jobConfigPath = writeToTempFile(jobConfigString, "job_config_")
+
+      // Build DQ context
+      val dqContext = DQContext.build(
+        appConfigPath, Some("2024-01-05"),
+        isLocal = true, isShared = true,
+        logLvl = Level.WARN
+      )
+      dqContext.left.foreach(errors => fail(s"DQContext build failed: ${errors.mkString("\n")}"))
+      val ctx = dqContext.toOption.get
+
+      // Build job from config file
+      val jobConfig = readJobConfig[File](new File(jobConfigPath)).toOption.get
+      val job = ctx.buildBatchJob(jobConfig)
+      job.left.foreach(errors => fail(s"Job build failed: ${errors.mkString("\n")}"))
+      job.isRight shouldEqual true
+
+      // Run job
+      val resultSet = job.toOption.get.run
+      resultSet.isRight shouldEqual true
+      val results = resultSet.toOption.get
+
+      // Verify metrics
+      val metrics = results.regularMetrics
+      val rowCnt = metrics.find(_.metricId == "sales_row_cnt").get
+      rowCnt.result shouldEqual 10.0
+
+      val amountNulls = metrics.find(_.metricId == "sales_amount_nulls").get
+      amountNulls.result shouldEqual 2.0
+
+      val categoryNulls = metrics.find(_.metricId == "sales_category_nulls").get
+      categoryNulls.result shouldEqual 1.0
+
+      val completeness = metrics.find(_.metricId == "sales_amount_completeness").get
+      completeness.result shouldEqual 0.8
+
+      val distinctProducts = metrics.find(_.metricId == "sales_distinct_products").get
+      distinctProducts.result shouldEqual 4.0
+
+      val distinctRegions = metrics.find(_.metricId == "sales_distinct_regions").get
+      distinctRegions.result shouldEqual 4.0
+
+      // Verify checks
+      val checks = results.checks
+      checks should have size 5
+
+      val hasRows = checks.find(_.checkId == "has_rows").get
+      hasRows.status shouldEqual "Success"
+
+      val completenessCheck = checks.find(_.checkId == "completeness_above_70pct").get
+      completenessCheck.status shouldEqual "Success"
+
+      val nullsCheck = checks.find(_.checkId == "amount_nulls_below_5").get
+      nullsCheck.status shouldEqual "Success"
+
+      val productsCheck = checks.find(_.checkId == "exactly_4_products").get
+      productsCheck.status shouldEqual "Success"
+
+      val regionsCheck = checks.find(_.checkId == "exactly_4_regions").get
+      regionsCheck.status shouldEqual "Success"
+
+      // No failure tolerance violations
+      results.failureToleranceViolationChecks shouldBe empty
+    }
+  }
+}

--- a/checkita-core/src/test/scala/org/checkita/dqf/connections/jdbc/GenericJdbcOpenSearchSpec.scala
+++ b/checkita-core/src/test/scala/org/checkita/dqf/connections/jdbc/GenericJdbcOpenSearchSpec.scala
@@ -1,0 +1,166 @@
+package org.checkita.dqf.connections.jdbc
+
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.types.string.NonEmptyString
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.checkita.dqf.Common._
+import org.checkita.dqf.config.RefinedTypes.ID
+import org.checkita.dqf.config.jobconf.Connections.GenericJdbcConnectionConfig
+import org.checkita.dqf.config.jobconf.Sources.TableSourceConfig
+import org.checkita.dqf.connections.IntegrationTestTag
+import org.checkita.dqf.readers.ConnectionReaders._
+import org.checkita.dqf.readers.SchemaReaders.SourceSchema
+import org.testcontainers.containers.wait.strategy.Wait
+
+import java.net.{HttpURLConnection, URL}
+import java.time.Duration
+
+/**
+ * Integration test for GenericJdbcConnection with OpenSearch.
+ * Requires a running container runtime (Docker/Podman).
+ */
+class GenericJdbcOpenSearchSpec extends AnyWordSpec with Matchers with ForAllTestContainer {
+
+  override val container: GenericContainer = GenericContainer(
+    dockerImage = "opensearchproject/opensearch:2.11.0",
+    exposedPorts = Seq(9200),
+    env = Map(
+      "discovery.type" -> "single-node",
+      "plugins.security.disabled" -> "true",
+      "OPENSEARCH_INITIAL_ADMIN_PASSWORD" -> "Admin_12345"
+    ),
+    waitStrategy = Wait.forHttp("/")
+      .forPort(9200)
+      .forStatusCode(200)
+      .withStartupTimeout(Duration.ofSeconds(120))
+  )
+
+  implicit val schemas: Map[String, SourceSchema] = Map.empty
+
+  private def osUrl: String = s"jdbc:opensearch://localhost:${container.mappedPort(9200)}"
+
+  private def httpUrl: String = s"http://localhost:${container.mappedPort(9200)}"
+
+  private def validConfig: GenericJdbcConnectionConfig = GenericJdbcConnectionConfig(
+    id          = ID("opensearch_test"),
+    description = None,
+    url         = Refined.unsafeApply(osUrl),
+    driver      = NonEmptyString.unsafeFrom("org.opensearch.jdbc.Driver"),
+    username    = None,
+    password    = None,
+    schema      = None
+  )
+
+  private def tableSource(connId: String,
+                          table: Option[String] = None,
+                          query: Option[String] = None): TableSourceConfig =
+    TableSourceConfig(
+      id          = ID("os_source"),
+      description = None,
+      connection  = ID(connId),
+      table       = table.map(NonEmptyString.unsafeFrom),
+      query       = query.map(NonEmptyString.unsafeFrom),
+      persist     = None
+    )
+
+  private def httpPut(path: String, body: String): Int = {
+    val conn = new URL(s"$httpUrl$path").openConnection().asInstanceOf[HttpURLConnection]
+    conn.setRequestMethod("PUT")
+    conn.setDoOutput(true)
+    conn.setRequestProperty("Content-Type", "application/json")
+    conn.getOutputStream.write(body.getBytes("UTF-8"))
+    conn.getOutputStream.close()
+    val code = conn.getResponseCode
+    conn.disconnect()
+    code
+  }
+
+  private def httpPost(path: String, body: String): Int = {
+    val conn = new URL(s"$httpUrl$path").openConnection().asInstanceOf[HttpURLConnection]
+    conn.setRequestMethod("POST")
+    conn.setDoOutput(true)
+    conn.setRequestProperty("Content-Type", "application/json")
+    conn.getOutputStream.write(body.getBytes("UTF-8"))
+    conn.getOutputStream.close()
+    val code = conn.getResponseCode
+    conn.disconnect()
+    code
+  }
+
+  private def seedCompanies(): Unit = {
+    httpPut("/test_companies", """{
+      "mappings": {
+        "properties": {
+          "id": {"type": "integer"},
+          "name": {"type": "keyword"},
+          "revenue": {"type": "double"}
+        }
+      }
+    }""")
+    httpPut("/test_companies/_doc/1", """{"id": 1, "name": "Foo Corp", "revenue": 100.5}""")
+    httpPut("/test_companies/_doc/2", """{"id": 2, "name": "Bar Ltd", "revenue": 200.0}""")
+    httpPut("/test_companies/_doc/3", """{"id": 3, "name": "Baz Inc", "revenue": 300.75}""")
+    httpPost("/test_companies/_refresh", "")
+  }
+
+  private def seedMultiTypeData(): Unit = {
+    httpPut("/multi_type", """{
+      "mappings": {
+        "properties": {
+          "id": {"type": "integer"},
+          "name": {"type": "keyword"},
+          "active": {"type": "boolean"}
+        }
+      }
+    }""")
+    httpPut("/multi_type/_doc/1", """{"id": 1, "name": "Alice", "active": true}""")
+    httpPut("/multi_type/_doc/2", """{"id": 2, "name": "Bob", "active": false}""")
+    httpPost("/multi_type/_refresh", "")
+  }
+
+  "GenericJdbcConnection with OpenSearch" must {
+
+    "pass checkConnection against a running instance" taggedAs IntegrationTestTag in {
+      val result = validConfig.read
+      result.isRight shouldEqual true
+    }
+
+    "fail checkConnection when OpenSearch is unreachable" taggedAs IntegrationTestTag in {
+      val badConfig = validConfig.copy(
+        id  = ID("os_bad"),
+        url = Refined.unsafeApply("jdbc:opensearch://localhost:19999")
+      )
+      badConfig.read.isLeft shouldEqual true
+    }
+
+    "connect and read data from OpenSearch index" taggedAs IntegrationTestTag in {
+      seedCompanies()
+
+      val conn = GenericJdbcConnection(validConfig)
+      val df = conn.loadDataFrame(tableSource("opensearch_test", table = Some("test_companies")))
+      df.count() shouldEqual 3
+      df.columns.map(_.toLowerCase) should contain allOf("id", "name", "revenue")
+    }
+
+    "read data from OpenSearch using SQL query" taggedAs IntegrationTestTag in {
+      val conn = GenericJdbcConnection(validConfig)
+      val df = conn.loadDataFrame(tableSource(
+        "opensearch_test",
+        query = Some("SELECT * FROM test_companies WHERE revenue > 150")
+      ))
+      df.count() shouldEqual 2
+    }
+
+    "handle multiple data types (integer, keyword, boolean)" taggedAs IntegrationTestTag in {
+      seedMultiTypeData()
+
+      val conn = GenericJdbcConnection(validConfig)
+      val df = conn.loadDataFrame(tableSource("opensearch_test", table = Some("multi_type")))
+
+      df.count() shouldEqual 2
+      df.columns.map(_.toLowerCase) should contain allOf("id", "name", "active")
+    }
+  }
+}

--- a/docs/03-job-configuration/01-Connections.md
+++ b/docs/03-job-configuration/01-Connections.md
@@ -14,6 +14,8 @@ systems are supported:
     * MS SQL
     * H2
     * ClickHouse
+* Generic JDBC connection to any JDBC-compatible database (e.g. Trino, Vertica, OpenSearch)
+* Connection to Apache Iceberg tables via Spark catalog API
 * Connection to message queues:
     * Kafka
 * Connection to Greenplum via pivotal connector
@@ -106,6 +108,12 @@ Configuration to MS SQL can be set up similarly to the 3 previous, using followi
 * `metadata` - *Optional*. List of user-defined metadata parameters specific to this connection where each parameter
   is a string in format: `param.name=param.value`.
 
+> **Note:** Starting from version 2.3.0 the built-in MS SQL connection uses the official Microsoft JDBC driver
+> (`com.microsoft.sqlserver.jdbc.SQLServerDriver`) instead of the legacy jTDS driver. The configuration format
+> remains unchanged — no modifications to existing job configs are required. The jTDS driver JAR is still
+> included in the distribution and can be used via the [Generic JDBC connection](#generic-jdbc-connection-configuration)
+> if needed for backward compatibility.
+
 ## H2 Connection Configuration
 
 Configuring connection to H2 database has similarly to SQLite. It is required supplying only two parameters:
@@ -167,6 +175,163 @@ command as follows:
   --conf 'spark.executor.extraJavaOptions="-Djava.security.auth.login.config=./jaas.conf"' \
   --files file.keytab,jaas.conf,<other files required for DQ>
   ```
+
+## Generic JDBC Connection Configuration
+
+Generic JDBC connection allows connecting to any JDBC-compatible database that is not explicitly supported
+by the framework (e.g. Trino, Vertica, OpenSearch, CockroachDB). The user must provide the full JDBC URL
+and the driver class name. The JDBC driver JAR must be added to the Spark application classpath
+(e.g. via `spark.jars` configuration parameter).
+
+Configuration parameters:
+
+* `id` - *Required*. Connection ID;
+* `description` - *Optional*. Connection description;
+* `url` - *Required*. Full JDBC URL including the protocol, e.g. `jdbc:trino://host:8080/catalog/schema`
+  or `jdbc:vertica://host:5433/mydb`.
+* `driver` - *Required*. Fully qualified JDBC driver class name, e.g. `io.trino.jdbc.TrinoDriver`
+  or `com.vertica.jdbc.Driver`.
+* `username` - *Optional*. Username used for connection.
+* `password` - *Optional*. Password used for connection.
+* `schema` - *Optional*. Schema to lookup tables from. If omitted, default schema is used.
+* `parameters` - *Optional*. List of Spark parameters if required where each parameter is a string in format:
+  `spark.param.name=spark.param.value`.
+* `metadata` - *Optional*. List of user-defined metadata parameters specific to this connection where each parameter
+  is a string in format: `param.name=param.value`.
+
+### Trino Example
+
+```hocon
+jdbc: [
+  {
+    id: "trino_analytics"
+    url: "jdbc:trino://trino-host:8080/hive/default"
+    driver: "io.trino.jdbc.TrinoDriver"
+    username: "dq-user"
+  }
+]
+```
+
+Requires `trino-jdbc` JAR on the classpath.
+
+### Vertica Example
+
+```hocon
+jdbc: [
+  {
+    id: "vertica_dwh"
+    url: "jdbc:vertica://vertica-host:5433/analytics"
+    driver: "com.vertica.jdbc.Driver"
+    username: "dbadmin"
+    password: "secret"
+    schema: "public"
+  }
+]
+```
+
+Requires `vertica-jdbc` JAR on the classpath.
+
+### OpenSearch Example
+
+```hocon
+jdbc: [
+  {
+    id: "opensearch_logs"
+    url: "jdbc:opensearch://opensearch-host:9200"
+    driver: "org.opensearch.jdbc.Driver"
+    parameters: ["fetchSize=1000"]
+  }
+]
+```
+
+Requires `opensearch-sql-jdbc` JAR on the classpath. Note that OpenSearch SQL support has limitations
+compared to traditional RDBMS — not all SQL operations may be available.
+
+### MS SQL with Legacy jTDS Driver
+
+If you need to use the legacy jTDS driver (e.g. for compatibility with older MS SQL versions),
+you can use it via generic JDBC instead of the built-in `mssql` connection:
+
+```hocon
+jdbc: [
+  {
+    id: "mssql_jtds"
+    url: "jdbc:jtds:sqlserver://host:1433/mydb"
+    driver: "net.sourceforge.jtds.jdbc.Driver"
+    username: "user"
+    password: "pass"
+  }
+]
+```
+
+The jTDS driver JAR is included in the Checkita distribution.
+
+## Iceberg Connection Configuration
+
+Iceberg connection allows reading Apache Iceberg tables through the Spark catalog API. The connection
+configures a Spark SQL catalog that points to an Iceberg catalog service (Hive Metastore, REST, Hadoop,
+Glue, Nessie). The `iceberg-spark-runtime` JAR must be added to the Spark application classpath.
+
+Configuration parameters:
+
+* `id` - *Required*. Connection ID;
+* `description` - *Optional*. Connection description;
+* `catalogName` - *Required*. Spark catalog name used to register the Iceberg catalog.
+  Must be unique across all Iceberg connections.
+* `catalogType` - *Required*. Iceberg catalog type. Supported values: `hadoop`, `hive`, `rest`, `glue`, `nessie`.
+* `warehouse` - *Optional*. Warehouse location — a path or URI to the root of the Iceberg warehouse
+  (e.g. `hdfs:///data/warehouse`, `s3a://bucket/warehouse`, or a local path).
+* `catalogUri` - *Optional*. Catalog service URI. Required for `hive` (Thrift URI), `rest` (HTTP endpoint),
+  and `nessie` catalog types.
+* `parameters` - *Optional*. List of additional catalog parameters where each parameter is a string in format:
+  `param.name=param.value`. These are passed as `spark.sql.catalog.<catalogName>.<param.name>` properties.
+* `metadata` - *Optional*. List of user-defined metadata parameters specific to this connection where each parameter
+  is a string in format: `param.name=param.value`.
+
+### Iceberg with Hive Metastore and HDFS
+
+```hocon
+iceberg: [
+  {
+    id: "iceberg_prod"
+    catalogName: "ice"
+    catalogType: "hive"
+    warehouse: "hdfs:///data/warehouse"
+    catalogUri: "thrift://hive-metastore:9083"
+  }
+]
+```
+
+### Iceberg with REST Catalog and S3
+
+```hocon
+iceberg: [
+  {
+    id: "iceberg_lakehouse"
+    catalogName: "lakehouse"
+    catalogType: "rest"
+    warehouse: "s3a://my-bucket/iceberg"
+    catalogUri: "https://iceberg-catalog.company.com"
+    parameters: ["io-impl=org.apache.iceberg.aws.s3.S3FileIO"]
+  }
+]
+```
+
+### Iceberg with Hadoop Catalog (local/HDFS)
+
+```hocon
+iceberg: [
+  {
+    id: "iceberg_local"
+    catalogName: "local_ice"
+    catalogType: "hadoop"
+    warehouse: "/tmp/iceberg/warehouse"
+  }
+]
+```
+
+**Note:** Iceberg sources are configured separately in the `sources.iceberg` section.
+See [Sources Configuration](03-Sources.md) for details.
 
 ## Greenplum Connection Configuration (via pivotal)
 
@@ -252,11 +417,35 @@ jobConfig: {
         ]
       }
     ],
+    jdbc: [
+      {
+        id: "trino_conn"
+        url: "jdbc:trino://trino-host:8080/hive/default"
+        driver: "io.trino.jdbc.TrinoDriver"
+        username: "dq-user"
+      }
+      {
+        id: "vertica_conn"
+        url: "jdbc:vertica://vertica-host:5433/analytics"
+        driver: "com.vertica.jdbc.Driver"
+        username: "dbadmin"
+        password: "pass"
+      }
+    ],
+    iceberg: [
+      {
+        id: "iceberg_prod"
+        catalogName: "ice"
+        catalogType: "hive"
+        warehouse: "hdfs:///data/warehouse"
+        catalogUri: "thrift://hive-metastore:9083"
+      }
+    ],
     greenplum: [
       {
-        id: "greenplum_db1", 
-        url: "greenplum.db.com:5432/postgres", 
-        username: "user", 
+        id: "greenplum_db1",
+        url: "greenplum.db.com:5432/postgres",
+        username: "user",
         password: "pass",
         schema: "public"
       }

--- a/docs/03-job-configuration/03-Sources.md
+++ b/docs/03-job-configuration/03-Sources.md
@@ -15,14 +15,15 @@ Additionally, it is possible to cache sources that in memory or on disk in order
 This could be handful when source is used as a parent for more than one virtual source.
 In such cases caching source allows not to calculate it multiple times.
 
-Thus, currently Checkita supports four general types of sources:
+Thus, currently Checkita supports the following types of sources:
 
 * File sources: read files from local or remote file systems (HDFS, S3, etc.);
 * Hive sources: read hive table from Hive catalogue;
-* Table sources: read tables from RDBMS via JDBC connection.
+* Table sources: read tables from RDBMS via JDBC connection (including Generic JDBC for Trino, Vertica, OpenSearch, etc.);
+* Iceberg sources: read Apache Iceberg tables via Spark catalog API;
 * Kafka sources: read topics from Kafka.
 * Greenplum sources: read tables from Greenplum via Pivotal Greenplum connector.
-* Custom sources: read from sources that are not supported directly in job configuration by providing 
+* Custom sources: read from sources that are not supported directly in job configuration by providing
   all required Spark options to connect and read from unsupported source.
 
 All sources must be defined in `sources` section of job configuration. 
@@ -229,6 +230,55 @@ data quality checks.
 
 > *TIP*: In order to define JSON strings, they must be enclosed in triple quotes:
 > `"""{"name1": {"name2": "value2", "name3": "value3""}}"""`.
+
+## Iceberg Sources Configuration
+
+Iceberg sources read Apache Iceberg tables via Spark catalog API. The source must reference an Iceberg connection
+that configures the catalog. See [Connections Configuration](01-Connections.md) chapter for more details on
+Iceberg connection setup.
+
+Configuration parameters:
+
+* `id` - *Required*. Source ID;
+* `description` - *Optional*. Source description;
+* `connection` - *Required*. Connection ID to use for reading. Must refer to an Iceberg connection.
+* `table` - *Required*. Name of the Iceberg table to read.
+* `database` - *Optional*. Database (namespace) within the Iceberg catalog.
+  If omitted, the `default` namespace is used.
+* `persist` - *Optional*. One of the allowed Spark StorageLevels used to cache sources.
+  By default, sources are not cached. Supported Spark StorageLevels are:
+    * `NONE`, `DISK_ONLY`, `DISK_ONLY_2`, `MEMORY_ONLY`, `MEMORY_ONLY_2`, `MEMORY_ONLY_SER`,
+      `MEMORY_ONLY_SER_2`, `MEMORY_AND_DISK`, `MEMORY_AND_DISK_2`, `MEMORY_AND_DISK_SER`,
+      `MEMORY_AND_DISK_SER_2`, `OFF_HEAP`.
+* `options` - *Optional*. Additional Spark parameters used to read from the given source.
+* `keyFields` - *Optional*. List of columns that form a Primary Key or are used to identify row within a dataset.
+* `metadata` - *Optional*. List of user-defined metadata parameters specific to this source where each parameter
+  is a string in format: `param.name=param.value`.
+
+Example:
+
+```hocon
+sources: {
+  iceberg: [
+    {
+      id: "orders_source"
+      connection: "iceberg_prod"
+      table: "orders"
+      database: "analytics"
+      keyFields: ["order_id"]
+    }
+    {
+      id: "users_source"
+      connection: "iceberg_prod"
+      table: "users"
+      // database omitted — reads from "default" namespace
+    }
+  ]
+}
+```
+
+**Note:** The `iceberg-spark-runtime` JAR must be on the Spark classpath.
+The framework does not bundle it — the user must provide it during `spark-submit`.
 
 ## Greenplum Sources Configuration
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -1,3 +1,24 @@
+## [Unreleased]
+
+### Features
+
+* **Generic JDBC connector** — universal JDBC connection for any database (Trino, Vertica, OpenSearch, etc.)
+  via full JDBC URL and driver class name. Key: `connections.jdbc`.
+* **Apache Iceberg connector** — read Iceberg tables via Spark catalog API with support for
+  Hadoop, Hive, REST, Glue, and Nessie catalog types. Key: `connections.iceberg`, `sources.iceberg`.
+
+### Improvements
+
+* **MS SQL driver upgrade** — built-in MS SQL connection switched from legacy jTDS (2013) to official
+  Microsoft JDBC driver. No config changes required. jTDS JAR still included for backward compatibility
+  via Generic JDBC.
+
+### Tests
+
+* Integration tests with testcontainers for OpenSearch, Iceberg REST catalog, and Vertica.
+* CI workflow for integration tests (PR: 2 combos, nightly: full matrix).
+* sbt alias `integrationTest` for running integration tests locally.
+
 ## [2.2.0](https://github.com/Raiffeisen-DGTL/checkita-data-quality/compare/v2.1.0...v2.2.0) (2024-12-27)
 
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -66,6 +66,12 @@ object Dependencies {
   val scalaTest = "org.scalatest" %% "scalatest" % "3.2.15" % Test
   val scalaCollCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.12.0"
 
+  // Testcontainers
+  val testcontainersScalatest = "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.41.0" % Test
+
+  // JDBC drivers for integration tests
+  val opensearchJdbc = "org.opensearch.driver" % "opensearch-sql-jdbc" % "1.4.0.1" % Test
+
   //JSQL
   val jsql = "com.github.jsqlparser" % "jsqlparser" % "4.5"
   
@@ -100,7 +106,9 @@ object Dependencies {
     schemaRegistry,
     scalaTest,
     scalaCollCompat,
-    sparkXml
+    sparkXml,
+    testcontainersScalatest,
+    opensearchJdbc
   )
 
   val checkita_api: Seq[ModuleID] = Seq(

--- a/project/Utils.scala
+++ b/project/Utils.scala
@@ -49,7 +49,11 @@ object Utils {
       }.get
     )
 
-    sparkDeps ++ sparkKafkaDeps ++ extraDeps ++ log4j2
+    val icebergTestDeps: Map[String, ModuleID] = Map(
+      "icebergRuntime" -> ("org.apache.iceberg" %% s"iceberg-spark-runtime-${sparkVersion.take(3)}" % "1.4.3" % Test)
+    )
+
+    sparkDeps ++ sparkKafkaDeps ++ extraDeps ++ icebergTestDeps ++ log4j2
   }
 
   def getExcludeDependencies(sparkVersion: String): Seq[ExclusionRule] =


### PR DESCRIPTION
 ## Summary

  - **Generic JDBC connector** — universal JDBC connection for any database (Trino, Vertica,
  OpenSearch, etc.) via full JDBC URL and driver class name. Config key: `connections.jdbc`
  - **Apache Iceberg connector** — read Iceberg tables via Spark catalog API with support for
  Hadoop, Hive, REST, Glue and Nessie catalog types. Config keys: `connections.iceberg`,
  `sources.iceberg`
  - Unit tests (H2, Hadoop catalog) and integration tests with testcontainers (OpenSearch, Iceberg
  REST)
  - End-to-end test: full DQ pipeline (PostgreSQL → connection → source → metrics → checks)
  - CI workflow for integration tests
  - Documentation for all new connectors

  ## Vertica note

  Vertica is fully supported via Generic JDBC connector (`driver: "com.vertica.jdbc.Driver"`).
  Integration test for Vertica was removed because Vertica Community Edition Docker image
  is no longer publicly available (discontinued by OpenText). The `vertica-k8s` image
  requires Kubernetes operator and does not support standalone Docker mode.

  ## Test plan

  - [x] Unit tests pass (512 tests, 10 Scala/Spark combinations)
  - [x] Integration tests pass (OpenSearch, Iceberg REST, e2e PostgreSQL — 2 combinations)
  - [x] CI validated on fork: https://github.com/mehmehmeher/checkita-data-quality/pull/1